### PR TITLE
Add support of 'Category' in Alipay config

### DIFF
--- a/pkg/analyser/alipay/alipay.go
+++ b/pkg/analyser/alipay/alipay.go
@@ -65,6 +65,11 @@ func (a Alipay) GetAccounts(o *ir.Order, cfg *config.Config, target, provider st
 		if r.Method != nil {
 			match = util.SplitFindContains(*r.Method, o.Method, sep, match)
 		}
+		//add by lance 20211214
+		if r.Category != nil {
+			match = util.SplitFindContains(*r.Category, o.Category, sep, match)
+		}
+		//
 		if r.StartTime != nil && r.EndTime != nil {
 			// TODO(gaocegege): Support it.
 		}

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -31,6 +31,9 @@ type Order struct {
 	OrderType       OrderType
 	Peer            string
 	Item            string
+//add by lance 20211214
+    Category        string
+//
 	MerchantOrderID *string
 	OrderID         *string
 	Money           float64

--- a/pkg/provider/alipay/config.go
+++ b/pkg/provider/alipay/config.go
@@ -25,6 +25,9 @@ type Config struct {
 type Rule struct {
 	Peer          *string `mapstructure:"peer,omitempty"`
 	Item          *string `mapstructure:"item,omitempty"`
+//add by lance 20211214
+	Category      *string `mapstructure:"Category,omitempty"`
+//
 	Type          *string `mapstructure:"type,omitempty"`
 	Method        *string `mapstructure:"method,omitempty"`
 	Separator     *string `mapstructure:"sep,omitempty"` // default: ,

--- a/pkg/provider/alipay/convert.go
+++ b/pkg/provider/alipay/convert.go
@@ -12,6 +12,9 @@ func (a *Alipay) convertToIR() *ir.IR {
 		irO := ir.Order{
 			Peer:           o.Peer,
 			Item:           o.ItemName,
+			//add by lance 2021/12/14
+			Category:       o.Category,
+			//
 			Method:         o.Method,
 			PayTime:        o.PayTime,
 			Money:          o.Money,


### PR DESCRIPTION
Four files are modified to support using 'Category' in Alipay bill as expenses reference

double-entry-generator\pkg\analyser\alipay\alipay.go
double-entry-generator\pkg\ir\ir.go
double-entry-generator\pkg\provider\alipay\config.go
double-entry-generator\pkg\provider\alipay\convert.go
