### PR TITLE
refact: clarify the `type` and `txType` in whole codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,8 +414,8 @@ title: 测试
 huobi:
   rules:
     - item: BTC/USDT,BTC1S/USDT  # multiple keywords with separator
-      type: 币币交易
-      txType: 买入
+      type: 买入
+      txType: 币币交易
       fullMatch: true
       sep: ','  # define separator as a comma
       cashAccount: Assets:Rule1:Cash
@@ -432,8 +432,8 @@ huobi:
 
 `huobi` 是火币相关的配置。它提供基于规则的匹配。可以指定：
 - `item`（交易对）的完全/包含匹配。
-- `type`（交易类型）的完全/包含匹配。
-- `txType`（交易方向）的完全/包含匹配。
+- `type`（交易方向）的完全/包含匹配。
+- `txType`（交易类型）的完全/包含匹配。
 - `time`（交易时间）的区间匹配。
   > 交易时间可写为以下两种形式：
   > - `11:00-13:00`
@@ -472,7 +472,7 @@ title: 测试
 htsec:
   rules:
     - item: 兴业转债
-      txType: 卖
+      type: 卖
       sep: ','
       cashAccount: Assets:Rule1:Cash
       positionAccount: Assets:Rule1:Positions
@@ -488,7 +488,7 @@ htsec:
 
 `htsec` 是海通证券相关的配置。它提供基于规则的匹配。可以指定：
 - `item`（交易方向-证券编码-证券市值）的完全/包含匹配。
-- `txType`（交易方向）的完全/包含匹配。
+- `type`（交易方向）的完全/包含匹配。
 - `time`（交易时间）的区间匹配。
   > 交易时间可写为以下两种形式：
   > - `11:00-13:00`

--- a/example/htsec/config.yaml
+++ b/example/htsec/config.yaml
@@ -7,7 +7,7 @@ title: 测试
 htsec:
   rules:
     - item: 兴业转债
-      txType: 卖
+      type: 卖
       sep: ','
       cashAccount: Assets:Rule1:Cash
       positionAccount: Assets:Rule1:Positions

--- a/example/huobi/config.yaml
+++ b/example/huobi/config.yaml
@@ -7,8 +7,8 @@ title: 测试
 huobi:
   rules:
     - item: BTC/USDT,BTC1S/USDT
-      type: 币币交易
-      txType: 买入
+      type: 买入
+      txType: 币币交易
       fullMatch: true
       sep: ','
       cashAccount: Assets:Rule1:Cash

--- a/pkg/analyser/alipay/alipay.go
+++ b/pkg/analyser/alipay/alipay.go
@@ -51,7 +51,7 @@ func (a Alipay) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, prov
 	var err error
 	for _, r := range cfg.Alipay.Rules {
 		match := true
-		// get seperator
+		// get separator
 		sep := ","
 		if r.Separator != nil {
 			sep = *r.Separator
@@ -66,7 +66,7 @@ func (a Alipay) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, prov
 			match = matchFunc(*r.Peer, o.Peer, sep, match)
 		}
 		if r.Type != nil {
-			match = matchFunc(*r.Type, o.TxTypeOriginal, sep, match)
+			match = matchFunc(*r.Type, o.TypeOriginal, sep, match)
 		}
 		if r.Item != nil {
 			match = matchFunc(*r.Item, o.Item, sep, match)
@@ -94,14 +94,14 @@ func (a Alipay) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, prov
 			// Support multiple matches, like one rule matches the
 			// minus account, the other rule matches the plus account.
 			if r.TargetAccount != nil {
-				if o.TxType == ir.TxTypeRecv {
+				if o.Type == ir.TypeRecv {
 					resMinus = *r.TargetAccount
 				} else {
 					resPlus = *r.TargetAccount
 				}
 			}
 			if r.MethodAccount != nil {
-				if o.TxType == ir.TxTypeRecv {
+				if o.Type == ir.TypeRecv {
 					resPlus = *r.MethodAccount
 				} else {
 					resMinus = *r.MethodAccount

--- a/pkg/analyser/htsec/htsec.go
+++ b/pkg/analyser/htsec/htsec.go
@@ -58,10 +58,10 @@ func (h Htsec) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, provi
 	var err error
 	for _, r := range cfg.Htsec.Rules {
 		match := true
-		// get seperator
+		// get separator
 		sep := ","
-		if r.Seperator != nil {
-			sep = *r.Seperator
+		if r.Separator != nil {
+			sep = *r.Separator
 		}
 
 		matchFunc := util.SplitFindContains
@@ -69,8 +69,8 @@ func (h Htsec) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, provi
 			matchFunc = util.SplitFindEquals
 		}
 
-		if r.TxType != nil {
-			match = matchFunc(*r.TxType, o.TxTypeOriginal, sep, match)
+		if r.Type != nil {
+			match = matchFunc(*r.Type, o.TypeOriginal, sep, match)
 		}
 		if r.Item != nil {
 			match = matchFunc(*r.Item, o.Item, sep, match)

--- a/pkg/analyser/huobi/huobi.go
+++ b/pkg/analyser/huobi/huobi.go
@@ -58,10 +58,10 @@ func (h Huobi) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, provi
 	var err error
 	for _, r := range cfg.Huobi.Rules {
 		match := true
-		// get seperator
+		// get separator
 		sep := ","
-		if r.Seperator != nil {
-			sep = *r.Seperator
+		if r.Separator != nil {
+			sep = *r.Separator
 		}
 
 		matchFunc := util.SplitFindContains

--- a/pkg/analyser/wechat/wechat.go
+++ b/pkg/analyser/wechat/wechat.go
@@ -63,11 +63,10 @@ func (w Wechat) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, prov
 	var err error
 	for _, r := range cfg.Wechat.Rules {
 		match := true
-		// get seperator
+		// get separator
 		sep := ","
-
-		if r.Seperator != nil {
-			sep = *r.Seperator
+		if r.Separator != nil {
+			sep = *r.Separator
 		}
 
 		matchFunc := util.SplitFindContains
@@ -79,10 +78,10 @@ func (w Wechat) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, prov
 			match = matchFunc(*r.Peer, o.Peer, sep, match)
 		}
 		if r.Type != nil {
-			match = matchFunc(*r.Type, o.TxTypeOriginal, sep, match)
+			match = matchFunc(*r.Type, o.TypeOriginal, sep, match)
 		}
 		if r.TxType != nil {
-			match = matchFunc(*r.TxType, o.TypeOriginal, sep, match)
+			match = matchFunc(*r.TxType, o.TxTypeOriginal, sep, match)
 		}
 		if r.Method != nil {
 			match = matchFunc(*r.Method, o.Method, sep, match)
@@ -106,14 +105,14 @@ func (w Wechat) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, prov
 		if match {
 			// Support multiple matches, like one rule matches the minus accout, the other rule matches the plus account.
 			if r.TargetAccount != nil {
-				if o.TxType == ir.TxTypeRecv {
+				if o.Type == ir.TypeRecv {
 					resMinus = *r.TargetAccount
 				} else {
 					resPlus = *r.TargetAccount
 				}
 			}
 			if r.MethodAccount != nil {
-				if o.TxType == ir.TxTypeRecv {
+				if o.Type == ir.TypeRecv {
 					resPlus = *r.MethodAccount
 				} else {
 					resMinus = *r.MethodAccount

--- a/pkg/compiler/beancount/compiler.go
+++ b/pkg/compiler/beancount/compiler.go
@@ -189,8 +189,8 @@ func (b *BeanCount) writeBill(file *os.File, index int) error {
 			Tags:              o.Tags,
 		})
 	case ir.OrderTypeHuobiTrade: // Huobi trades
-		switch o.TxType {
-		case ir.TxTypeSend: // buy
+		switch o.Type {
+		case ir.TypeSend: // buy
 			isDiffCommissionUnit := false
 			commissionUnit, ok := o.Units[ir.CommissionUnit]
 			if !ok {
@@ -209,8 +209,8 @@ func (b *BeanCount) writeBill(file *os.File, index int) error {
 				err = huobiTradeBuyOrderDiffCommissionUnitTemplate.Execute(&buf, &HuobiTradeBuyOrderVars{
 					PayTime:           o.PayTime,
 					Peer:              o.Peer,
-					TypeOriginal:      o.TypeOriginal,
 					TxTypeOriginal:    o.TxTypeOriginal,
+					TypeOriginal:      o.TypeOriginal,
 					Item:              o.Item,
 					Amount:            o.Amount,
 					Money:             o.Money,
@@ -228,8 +228,8 @@ func (b *BeanCount) writeBill(file *os.File, index int) error {
 				err = huobiTradeBuyOrderTemplate.Execute(&buf, &HuobiTradeBuyOrderVars{
 					PayTime:           o.PayTime,
 					Peer:              o.Peer,
-					TypeOriginal:      o.TypeOriginal,
 					TxTypeOriginal:    o.TxTypeOriginal,
+					TypeOriginal:      o.TypeOriginal,
 					Item:              o.Item,
 					Amount:            o.Amount,
 					Money:             o.Money,
@@ -244,12 +244,12 @@ func (b *BeanCount) writeBill(file *os.File, index int) error {
 					CommissionUnit:    o.Units[ir.CommissionUnit],
 				})
 			}
-		case ir.TxTypeRecv: // sell
+		case ir.TypeRecv: // sell
 			err = huobiTradeSellOrderTemplate.Execute(&buf, &HuobiTradeSellOrderVars{
 				PayTime:           o.PayTime,
 				Peer:              o.Peer,
-				TypeOriginal:      o.TypeOriginal,
 				TxTypeOriginal:    o.TxTypeOriginal,
+				TypeOriginal:      o.TypeOriginal,
 				Item:              o.Item,
 				Amount:            o.Amount,
 				Money:             o.Money,
@@ -267,13 +267,13 @@ func (b *BeanCount) writeBill(file *os.File, index int) error {
 			err = fmt.Errorf("Failed to get the TxType.")
 		}
 	case ir.OrderTypeSecuritiesTrade:
-		switch o.TxType {
-		case ir.TxTypeSend: // buy
+		switch o.Type {
+		case ir.TypeSend: // buy
 			err = htsecTradeBuyOrderTemplate.Execute(&buf, &HtsecTradeBuyOrderVars{
 				PayTime:           o.PayTime,
 				Peer:              o.Peer,
-				TypeOriginal:      o.TypeOriginal,
 				TxTypeOriginal:    o.TxTypeOriginal,
+				TypeOriginal:      o.TypeOriginal,
 				Item:              o.Item,
 				Amount:            o.Amount,
 				Money:             o.Money,
@@ -288,12 +288,12 @@ func (b *BeanCount) writeBill(file *os.File, index int) error {
 				CommissionUnit:    o.Units[ir.CommissionUnit],
 				Currency:          b.Config.DefaultCurrency,
 			})
-		case ir.TxTypeRecv: // sell
+		case ir.TypeRecv: // sell
 			err = htsecTradeSellOrderTemplate.Execute(&buf, &HtsecTradeSellOrderVars{
 				PayTime:           o.PayTime,
 				Peer:              o.Peer,
-				TypeOriginal:      o.TypeOriginal,
 				TxTypeOriginal:    o.TxTypeOriginal,
+				TypeOriginal:      o.TypeOriginal,
 				Item:              o.Item,
 				Amount:            o.Amount,
 				Money:             o.Money,

--- a/pkg/compiler/beancount/template.go
+++ b/pkg/compiler/beancount/template.go
@@ -33,7 +33,7 @@ type NormalOrderVars struct {
 }
 
 // 火币买入模版（手续费单位为购买单位货币）
-var huobiTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TypeOriginal }}" "{{ .TxTypeOriginal }}-{{ .Item }}"
+var huobiTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
 	{{ .CashAccount }} -{{ .Money | printf "%.8f" }} {{ .BaseUnit }}
 	{{ .PositionAccount }} {{ .Amount | printf "%.8f" }} {{ .TargetUnit }} { {{- .Price | printf "%.8f" }} {{ .BaseUnit -}} } @@ {{ .Money | printf "%.8f" }} {{ .BaseUnit }}
 	{{ .CashAccount }} -{{ .Commission | printf "%.8f" }} {{ .TargetUnit }} @ {{ .Price | printf "%.8f" }} {{ .BaseUnit }}
@@ -42,7 +42,7 @@ var huobiTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .
 `
 
 // 火币买入模版 2（手续费为特定货币）
-var huobiTradeBuyOrderDiffCommissionUnit = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TypeOriginal }}" "{{ .TxTypeOriginal }}-{{ .Item }}"
+var huobiTradeBuyOrderDiffCommissionUnit = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
 	{{ .CashAccount }} -{{ .Money | printf "%.8f" }} {{ .BaseUnit }}
 	{{ .PositionAccount }} {{ .Amount | printf "%.8f" }} {{ .TargetUnit }} { {{- .Price | printf "%.4f" }} {{ .BaseUnit -}} } @@ {{ .Money | printf "%.8f" }} {{ .BaseUnit }}
 	{{ .PositionAccount }} -{{ .Commission | printf "%.8f" }} {{ .CommissionUnit }}
@@ -53,8 +53,8 @@ var huobiTradeBuyOrderDiffCommissionUnit = `{{ .PayTime.Format "2006-01-02" }} *
 type HuobiTradeBuyOrderVars struct {
 	PayTime           time.Time
 	Peer              string
-	TypeOriginal      string
 	TxTypeOriginal    string
+	TypeOriginal      string
 	Item              string
 	CashAccount       string
 	PositionAccount   string
@@ -69,7 +69,8 @@ type HuobiTradeBuyOrderVars struct {
 	CommissionUnit    string
 }
 
-var huobiTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TypeOriginal }}" "{{ .TxTypeOriginal }}-{{ .Item }}"
+// 火币卖出模版
+var huobiTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
 	{{ .PositionAccount }} -{{ .Amount | printf "%.8f" }} {{ .TargetUnit }} {} @ {{ .Price | printf "%.8f" }} {{ .BaseUnit }}
 	{{ .CashAccount }} {{ .Money | printf "%.8f" }} {{ .BaseUnit }}
 	{{ .CashAccount }} -{{ .Commission | printf "%.8f" }} {{ .CommissionUnit }}
@@ -81,8 +82,8 @@ var huobiTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ 
 type HuobiTradeSellOrderVars struct {
 	PayTime           time.Time
 	Peer              string
-	TypeOriginal      string
 	TxTypeOriginal    string
+	TypeOriginal      string
 	Item              string
 	CashAccount       string
 	PositionAccount   string
@@ -98,9 +99,9 @@ type HuobiTradeSellOrderVars struct {
 }
 
 // 海通买入模版
-var htsecTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}" "{{ .TxTypeOriginal }}-{{ .Item }}"
+var htsecTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}" "{{ .TypeOriginal }}-{{ .Item }}"
 	{{ .CashAccount }} -{{ .Money | printf "%.2f" }} {{ .Currency }}
-	{{ .PositionAccount }} {{ .Amount | printf "%.2f" }} {{ .TypeOriginal }} { {{- .Price | printf "%.3f" }} {{ .Currency }}} @@ {{ .Money | printf "%.2f" }} {{ .Currency }}
+	{{ .PositionAccount }} {{ .Amount | printf "%.2f" }} {{ .TxTypeOriginal }} { {{- .Price | printf "%.3f" }} {{ .Currency }}} @@ {{ .Money | printf "%.2f" }} {{ .Currency }}
 	{{ .CashAccount }} -{{ .Commission | printf "%.2f" }} {{ .Currency }}
 	{{ .CommissionAccount }} {{ .Commission | printf "%.2f" }} {{ .Currency }}
 
@@ -109,8 +110,8 @@ var htsecTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}" "{{
 type HtsecTradeBuyOrderVars struct {
 	PayTime           time.Time
 	Peer              string
-	TypeOriginal      string
 	TxTypeOriginal    string
+	TypeOriginal      string
 	Item              string
 	CashAccount       string
 	PositionAccount   string
@@ -126,8 +127,8 @@ type HtsecTradeBuyOrderVars struct {
 	Currency          string
 }
 
-var htsecTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}" "{{ .TxTypeOriginal }}-{{ .Item }}"
-	{{ .PositionAccount }} -{{ .Amount | printf "%.2f" }} {{ .TypeOriginal }} {} @ {{ .Price | printf "%.3f" }} {{ .Currency }}
+var htsecTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}" "{{ .TypeOriginal }}-{{ .Item }}"
+	{{ .PositionAccount }} -{{ .Amount | printf "%.2f" }} {{ .TxTypeOriginal }} {} @ {{ .Price | printf "%.3f" }} {{ .Currency }}
 	{{ .CashAccount }} {{ .Money | printf "%.2f" }} {{ .Currency }}
 	{{ .CashAccount }} -{{ .Commission | printf "%.2f" }} {{ .Currency }}
 	{{ .CommissionAccount }} {{ .Commission | printf "%.2f" }} {{ .Currency }}
@@ -138,8 +139,8 @@ var htsecTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}" "{
 type HtsecTradeSellOrderVars struct {
 	PayTime           time.Time
 	Peer              string
-	TypeOriginal      string
 	TxTypeOriginal    string
+	TypeOriginal      string
 	Item              string
 	CashAccount       string
 	PositionAccount   string

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -37,9 +37,9 @@ type Order struct {
 	Money           float64
 	Note            string
 	PayTime         time.Time
-	TxType          TxType // 方向，一般为 收/支
-	TxTypeOriginal  string
+	Type            Type // 方向，一般为 收/支
 	TypeOriginal    string
+	TxTypeOriginal  string // 交易类型
 	Method          string
 	Amount          float64
 	Price           float64
@@ -73,13 +73,13 @@ const (
 	MinusAccount              = "MinusAccount"
 )
 
-// TxType is transanction type defined by alipay.
-type TxType string
+// Type is transaction type defined by alipay.
+type Type string
 
 const (
-	TxTypeSend    TxType = "Send"
-	TxTypeRecv           = "Recv"
-	TxTypeUnknown        = "Unknwon"
+	TypeSend    Type = "Send"
+	TypeRecv         = "Recv"
+	TypeUnknown      = "Unknwon"
 )
 
 type OrderType string // 为 IR 设置的交易类别

--- a/pkg/provider/alipay/convert.go
+++ b/pkg/provider/alipay/convert.go
@@ -10,15 +10,15 @@ func (a *Alipay) convertToIR() *ir.IR {
 	for _, o := range a.Orders {
 
 		irO := ir.Order{
-			Peer:           o.Peer,
-			Item:           o.ItemName,
-			Category:       o.Category,
-			Method:         o.Method,
-			PayTime:        o.PayTime,
-			Money:          o.Money,
-			OrderID:        &o.DealNo,
-			TxType:         conevertType(o.TxType),
-			TxTypeOriginal: o.TxTypeOriginal,
+			Peer:         o.Peer,
+			Item:         o.ItemName,
+			Category:     o.Category,
+			Method:       o.Method,
+			PayTime:      o.PayTime,
+			Money:        o.Money,
+			OrderID:      &o.DealNo,
+			Type:         conevertType(o.Type),
+			TypeOriginal: o.TypeOriginal,
 		}
 		irO.Metadata = getMetadata(o)
 		if o.MerchantId != "" {
@@ -29,14 +29,14 @@ func (a *Alipay) convertToIR() *ir.IR {
 	return i
 }
 
-func conevertType(t TxTypeType) ir.TxType {
+func conevertType(t Type) ir.Type {
 	switch t {
-	case TxTypeSend:
-		return ir.TxTypeSend
-	case TxTypeRecv:
-		return ir.TxTypeRecv
+	case TypeSend:
+		return ir.TypeSend
+	case TypeRecv:
+		return ir.TypeRecv
 	default:
-		return ir.TxTypeUnknown
+		return ir.TypeUnknown
 	}
 }
 
@@ -61,8 +61,8 @@ func getMetadata(o Order) map[string]string {
 		category = o.Category
 	}
 
-	if o.TxTypeOriginal != "" {
-		txType = o.TxTypeOriginal
+	if o.TypeOriginal != "" {
+		txType = o.TypeOriginal
 	}
 
 	if o.Method != "" {

--- a/pkg/provider/alipay/parse.go
+++ b/pkg/provider/alipay/parse.go
@@ -31,12 +31,12 @@ func (a *Alipay) translateToOrders(array []string) error {
 		array[idx] = a
 	}
 	var bill Order
-	bill.TxType = getTxType(array[0])
-	if bill.TxType == TxTypeNil {
+	bill.Type = getTxType(array[0])
+	if bill.Type == TypeNil {
 		log.Println("get tx type error:", array[0], array)
 		return fmt.Errorf("Failed to get the tx type %s", array[0])
 	}
-	bill.TxTypeOriginal = array[0]
+	bill.TypeOriginal = array[0]
 	bill.Peer = array[1]
 	bill.PeerAccount = array[2]
 	bill.ItemName = array[3]

--- a/pkg/provider/alipay/types.go
+++ b/pkg/provider/alipay/types.go
@@ -24,31 +24,31 @@ type Statistics struct {
 
 // Order is the single order.
 type Order struct {
-	TxType         TxTypeType `json:"txType,omitempty"` // 收/支
-	TxTypeOriginal string     `json:"txTypeOriginal,omitempty"`
-	Peer           string     `json:"peer,omitempty"`        // 交易对方
-	PeerAccount    string     `json:"peerAccount,omitempty"` // 对方账号
-	ItemName       string     `json:"itemName,omitempty"`    // 商品说明
-	Method         string     `json:"method,omitempty"`      // 收/付款方式
-	Money          float64    `json:"money,omitempty"`       // 金额
-	Status         string     `json:"status,omitempty"`      // 交易状态
-	Category       string     `json:"category,omitempty"`    // 交易分类
-	DealNo         string     `json:"dealNo,omitempty"`      // 交易订单号
-	MerchantId     string     `json:"merchantId,omitempty"`  // 商家订单号
-	PayTime        time.Time  `json:"payTime,omitempty"`     // 交易时间
+	Type         Type      `json:"type,omitempty"` // 收/支
+	TypeOriginal string    `json:"typeOriginal,omitempty"`
+	Peer         string    `json:"peer,omitempty"`        // 交易对方
+	PeerAccount  string    `json:"peerAccount,omitempty"` // 对方账号
+	ItemName     string    `json:"itemName,omitempty"`    // 商品说明
+	Method       string    `json:"method,omitempty"`      // 收/付款方式
+	Money        float64   `json:"money,omitempty"`       // 金额
+	Status       string    `json:"status,omitempty"`      // 交易状态
+	Category     string    `json:"category,omitempty"`    // 交易分类
+	DealNo       string    `json:"dealNo,omitempty"`      // 交易订单号
+	MerchantId   string    `json:"merchantId,omitempty"`  // 商家订单号
+	PayTime      time.Time `json:"payTime,omitempty"`     // 交易时间
 
 	// below is filled at runtime
 	TargetAccount string `json:"targetAccount,omitempty"`
 	MethodAccount string `json:"methodAccount,omitempty"`
 }
 
-// TxTypeType is transanction type defined by alipay.
-type TxTypeType string
+// Type is transanction type defined by alipay.
+type Type string
 
 const (
-	TxTypeSend   TxTypeType = "支出"
-	TxTypeRecv   TxTypeType = "收入"
-	TxTypeOthers TxTypeType = "其他"
-	TxTypeEmpty  TxTypeType = ""
-	TxTypeNil    TxTypeType = "未知"
+	TypeSend   Type = "支出"
+	TypeRecv   Type = "收入"
+	TypeOthers Type = "其他"
+	TypeEmpty  Type = ""
+	TypeNil    Type = "未知"
 )

--- a/pkg/provider/alipay/util.go
+++ b/pkg/provider/alipay/util.go
@@ -1,15 +1,15 @@
 package alipay
 
-func getTxType(str string) TxTypeType {
+func getTxType(str string) Type {
 	switch str {
-	case string(TxTypeSend):
-		return TxTypeSend
-	case string(TxTypeRecv):
-		return TxTypeRecv
-	case string(TxTypeOthers):
-		return TxTypeOthers
-	case string(TxTypeEmpty):
-		return TxTypeEmpty
+	case string(TypeSend):
+		return TypeSend
+	case string(TypeRecv):
+		return TypeRecv
+	case string(TypeOthers):
+		return TypeOthers
+	case string(TypeEmpty):
+		return TypeEmpty
 	}
-	return TxTypeNil
+	return TypeNil
 }

--- a/pkg/provider/htsec/config.go
+++ b/pkg/provider/htsec/config.go
@@ -6,11 +6,11 @@ type Config struct {
 
 type Rule struct {
 	// Peer              *string `mapstructure:"peer,omitempty"`
-	Item              *string `mapstructure:"item,omitempty"`   // "513050-中概互联"
-	TxType            *string `mapstructure:"txType,omitempty"` // "买"、"卖"
+	Item              *string `mapstructure:"item,omitempty"` // "513050-中概互联"
+	Type              *string `mapstructure:"type,omitempty"` // "买"、"卖"
 	Time              *string `mapstructure:"time,omitempty"`
 	TimestampRange    *string `mapstructure:"timestamp_range,omitempty"`
-	Seperator         *string `mapstructure:"sep,omitempty"` // default: ,
+	Separator         *string `mapstructure:"sep,omitempty"` // default: ,
 	CashAccount       *string `mapstructure:"cashAccount,omitempty"`
 	PositionAccount   *string `mapstructure:"positionAccount,omitempty"`
 	CommissionAccount *string `mapstructure:"commissionAccount,omitempty"`

--- a/pkg/provider/htsec/convert.go
+++ b/pkg/provider/htsec/convert.go
@@ -9,9 +9,9 @@ func (h *Htsec) convertToIR() *ir.IR {
 			OrderType:      ir.OrderTypeSecuritiesTrade,
 			Peer:           "htsec",
 			PayTime:        o.TransactionTime,
-			TypeOriginal:   o.TypeOriginal,
-			TxType:         convertType(o.TxType),
-			TxTypeOriginal: string(o.TxType),
+			TxTypeOriginal: o.TxTypeOriginal,
+			Type:           convertType(o.Type),
+			TypeOriginal:   string(o.Type),
 			Item:           o.SecuritiesName,
 			Money:          o.TransactionAmount,
 			Amount:         float64(o.Volume),
@@ -23,13 +23,13 @@ func (h *Htsec) convertToIR() *ir.IR {
 	return i
 }
 
-func convertType(t TxType) ir.TxType {
+func convertType(t OrderType) ir.Type {
 	switch t {
 	case TxTypeBuy:
-		return ir.TxTypeSend
+		return ir.TypeSend
 	case TxTypeSell:
-		return ir.TxTypeRecv
+		return ir.TypeRecv
 	default:
-		return ir.TxTypeUnknown
+		return ir.TypeUnknown
 	}
 }

--- a/pkg/provider/htsec/htsec.go
+++ b/pkg/provider/htsec/htsec.go
@@ -2,9 +2,10 @@ package htsec
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/deb-sig/double-entry-generator/pkg/ir"
 	"github.com/xuri/excelize/v2"
-	"log"
 )
 
 type Htsec struct {
@@ -52,7 +53,7 @@ func (h *Htsec) Translate(filename string) (*ir.IR, error) {
 
 		if o.Price != 0 && o.Volume != 0 && o.TransactionAmount == 0 {
 			for ti, tar := range h.Orders {
-				if o.TypeOriginal == tar.TypeOriginal && tar.TransactionAmount != 0 && tar.Price == 0 && tar.Volume == 0 {
+				if o.TxTypeOriginal == tar.TxTypeOriginal && tar.TransactionAmount != 0 && tar.Price == 0 && tar.Volume == 0 {
 					h.Orders[index].TransactionAmount = tar.TransactionAmount
 					h.Orders[index].OccurAmount = tar.OccurAmount
 

--- a/pkg/provider/htsec/parse.go
+++ b/pkg/provider/htsec/parse.go
@@ -32,9 +32,9 @@ func (h *Htsec) translateToOrders(arr []string) error {
 	}
 
 	if strings.HasPrefix(arr[17], "A") {
-		bill.TypeOriginal = "SH" + code
+		bill.TxTypeOriginal = "SH" + code
 	} else {
-		bill.TypeOriginal = "SZ" + code
+		bill.TxTypeOriginal = "SZ" + code
 	}
 	bill.SecuritiesName = code + "-" + arr[1]
 	if len(arr[3]) == 0 {
@@ -65,8 +65,8 @@ func (h *Htsec) translateToOrders(arr []string) error {
 		return fmt.Errorf("parse OccurAmount %s error: %v", arr[7], err)
 	}
 
-	bill.TxType = getTxType(arr[8])
-	if bill.TxType == TxTypeNil {
+	bill.Type = getTxType(arr[8])
+	if bill.Type == TxTypeNil {
 		return fmt.Errorf("Failed to get the tx type: %s: %v", arr[8], err)
 	}
 

--- a/pkg/provider/htsec/types.go
+++ b/pkg/provider/htsec/types.go
@@ -21,7 +21,7 @@ type Order struct {
 	Price             float64   // 成交价格
 	TransactionAmount float64   // 成交金额
 	OccurAmount       float64   // 发生金额
-	TxType            TxType    // 方向
+	Type              OrderType // 方向
 	OrderID           string    // 合同号
 	TransactionID     string    // 成交号
 	Commission        float64   // 手续费
@@ -30,7 +30,7 @@ type Order struct {
 	OtherFee          float64   // 其他费
 	RemainAmount      float64   // 资金余额
 	RemainShare       int64     // 份额余额
-	TypeOriginal      string    // 市场+证券代码
+	TxTypeOriginal    string    // 市场+证券代码
 	Useless           bool      // 需删除数据
 }
 
@@ -41,16 +41,7 @@ const LocalTimeFmt = "2006-01-02 15:04:05 -0700"
 type OrderType string
 
 const (
-	OrderTypeBuy     OrderType = "买"
-	OrderTypeSell    OrderType = "卖"
-	OrderTypeUnknown           = "未知"
-	// TODO(TripleZ): add more order types.
-)
-
-type TxType string
-
-const (
-	TxTypeBuy  TxType = "买"
-	TxTypeSell TxType = "卖"
-	TxTypeNil  TxType = "未知"
+	TxTypeBuy  OrderType = "买"
+	TxTypeSell OrderType = "卖"
+	TxTypeNil  OrderType = "未知"
 )

--- a/pkg/provider/htsec/util.go
+++ b/pkg/provider/htsec/util.go
@@ -1,6 +1,6 @@
 package htsec
 
-func getTxType(s string) TxType {
+func getTxType(s string) OrderType {
 	switch s {
 	case string(TxTypeBuy):
 		return TxTypeBuy

--- a/pkg/provider/huobi/config.go
+++ b/pkg/provider/huobi/config.go
@@ -7,11 +7,11 @@ type Config struct {
 type Rule struct {
 	// Peer              *string `mapstructure:"peer,omitempty"`
 	Item              *string `mapstructure:"item,omitempty"`   // "BTC/USDT"
-	Type              *string `mapstructure:"type,omitempty"`   // "币币交易"
-	TxType            *string `mapstructure:"txType,omitempty"` // "买入"、"卖出"
+	Type              *string `mapstructure:"type,omitempty"`   // "买入"、"卖出"
+	TxType            *string `mapstructure:"txType,omitempty"` // "币币交易"
 	Time              *string `mapstructure:"time,omitempty"`
 	TimestampRange    *string `mapstructure:"timestamp_range,omitempty"`
-	Seperator         *string `mapstructure:"sep,omitempty"` // default: ,
+	Separator         *string `mapstructure:"sep,omitempty"` // default: ,
 	CashAccount       *string `mapstructure:"cashAccount,omitempty"`
 	PositionAccount   *string `mapstructure:"positionAccount,omitempty"`
 	CommissionAccount *string `mapstructure:"commissionAccount,omitempty"`

--- a/pkg/provider/huobi/convert.go
+++ b/pkg/provider/huobi/convert.go
@@ -9,9 +9,9 @@ func (h *Huobi) convertToIR() *ir.IR {
 			OrderType:      ir.OrderTypeHuobiTrade,
 			Peer:           "Huobi",
 			PayTime:        o.PayTime,
-			TypeOriginal:   o.TypeOriginal,
-			TxType:         convertType(o.TxType),
-			TxTypeOriginal: string(o.TxType),
+			TxTypeOriginal: o.TxTypeOriginal,
+			Type:           convertType(o.Type),
+			TypeOriginal:   string(o.Type),
 			Item:           o.Item,
 			Money:          o.Money,
 			Amount:         o.Amount,
@@ -28,13 +28,13 @@ func (h *Huobi) convertToIR() *ir.IR {
 	return i
 }
 
-func convertType(t TxType) ir.TxType {
+func convertType(t OrderType) ir.Type {
 	switch t {
-	case TxTypeBuy:
-		return ir.TxTypeSend
-	case TxTypeSell:
-		return ir.TxTypeRecv
+	case TypeBuy:
+		return ir.TypeSend
+	case TypeSell:
+		return ir.TypeRecv
 	default:
-		return ir.TxTypeUnknown
+		return ir.TypeUnknown
 	}
 }

--- a/pkg/provider/huobi/parse.go
+++ b/pkg/provider/huobi/parse.go
@@ -22,11 +22,11 @@ func (h *Huobi) translateToOrders(arr []string) error {
 		return fmt.Errorf("parse create time %s error: %v", arr[0], err)
 	}
 
-	bill.Type = getOrderType(arr[1])
-	if bill.Type == OrderTypeUnknown {
+	bill.TxType = getTxType(arr[1])
+	if bill.TxType == TxTypeUnknown {
 		return fmt.Errorf("Failed to get the order type %s: %v", arr[1], err)
 	}
-	bill.TypeOriginal = arr[1]
+	bill.TxTypeOriginal = arr[1]
 
 	bill.Item = arr[2]
 	units := strings.Split(arr[2], "/")
@@ -36,8 +36,8 @@ func (h *Huobi) translateToOrders(arr []string) error {
 	bill.BaseUnit = units[1]
 	bill.TargetUnit = units[0]
 
-	bill.TxType = getTxType(arr[3])
-	if bill.TxType == TxTypeNil {
+	bill.Type = getOrderType(arr[3])
+	if bill.Type == TypeNil {
 		return fmt.Errorf("Failed to get the tx type: %s: %v", arr[3], err)
 	}
 	bill.Price, err = strconv.ParseFloat(arr[4], 64)

--- a/pkg/provider/huobi/types.go
+++ b/pkg/provider/huobi/types.go
@@ -16,10 +16,10 @@ type Statistics struct {
 
 type Order struct {
 	PayTime        time.Time // 付款时间
-	Type           OrderType // 类型
-	TypeOriginal   string    // 原始类型
+	TxType         TxType    // 类型
+	TxTypeOriginal string    // 原始类型
 	Item           string    // 交易对
-	TxType         TxType    // 方向
+	Type           OrderType // 方向
 	Price          float64   // 价格
 	Amount         float64   // 数量
 	Money          float64   // 成交额
@@ -32,19 +32,19 @@ type Order struct {
 // LocalTimeFmt set time format to utc+8
 const LocalTimeFmt = "2006-01-02 15:04:05 -0700"
 
-// OrderType is the type of the order.
-type OrderType string
-
-const (
-	OrderTypeCoin    OrderType = "币币交易"
-	OrderTypeUnknown           = "未知"
-	// TODO(TripleZ): add more order types.
-)
-
+// TxType is the type of the order.
 type TxType string
 
 const (
-	TxTypeBuy  TxType = "买入"
-	TxTypeSell TxType = "卖出"
-	TxTypeNil  TxType = "未知"
+	TxTypeCoin    TxType = "币币交易"
+	TxTypeUnknown        = "未知"
+	// TODO(TripleZ): add more order types.
+)
+
+type OrderType string
+
+const (
+	TypeBuy  OrderType = "买入"
+	TypeSell OrderType = "卖出"
+	TypeNil  OrderType = "未知"
 )

--- a/pkg/provider/huobi/util.go
+++ b/pkg/provider/huobi/util.go
@@ -1,21 +1,21 @@
 package huobi
 
-func getOrderType(s string) OrderType {
+func getTxType(s string) TxType {
 	switch s {
-	case string(OrderTypeCoin):
-		return OrderTypeCoin
+	case string(TxTypeCoin):
+		return TxTypeCoin
 	default:
-		return OrderTypeUnknown
+		return TxTypeUnknown
 	}
 }
 
-func getTxType(s string) TxType {
+func getOrderType(s string) OrderType {
 	switch s {
-	case string(TxTypeBuy):
-		return TxTypeBuy
-	case string(TxTypeSell):
-		return TxTypeSell
+	case string(TypeBuy):
+		return TypeBuy
+	case string(TypeSell):
+		return TypeSell
 	default:
-		return TxTypeNil
+		return TypeNil
 	}
 }

--- a/pkg/provider/wechat/config.go
+++ b/pkg/provider/wechat/config.go
@@ -27,7 +27,7 @@ type Rule struct {
 	Item              *string `mapstructure:"item,omitempty"`
 	Type              *string `mapstructure:"type,omitempty"`
 	TxType            *string `mapstructure:"txType,omitempty"`
-	Seperator         *string `mapstructure:"sep,omitempty"` // default: ,
+	Separator         *string `mapstructure:"sep,omitempty"` // default: ,
 	Method            *string `mapstructure:"method,omitempty"`
 	Time              *string `mapstructure:"time,omitempty"`
 	TimestampRange    *string `mapstructure:"timestamp_range,omitempty"`

--- a/pkg/provider/wechat/convert.go
+++ b/pkg/provider/wechat/convert.go
@@ -14,9 +14,9 @@ func (w *Wechat) convertToIR() *ir.IR {
 			PayTime:        o.PayTime,
 			Money:          o.Money,
 			OrderID:        &o.OrderID,
-			TxType:         conevertType(o.Type),
-			TxTypeOriginal: o.TypeOriginal,
-			TypeOriginal:   o.TxTypeOriginal,
+			Type:           conevertType(o.Type),
+			TypeOriginal:   o.TypeOriginal,
+			TxTypeOriginal: o.TxTypeOriginal,
 			Method:         o.Method,
 			Commission:     o.Commission,
 		}
@@ -29,14 +29,14 @@ func (w *Wechat) convertToIR() *ir.IR {
 	return i
 }
 
-func conevertType(t OrderType) ir.TxType {
+func conevertType(t OrderType) ir.Type {
 	switch t {
 	case OrderTypeSend:
-		return ir.TxTypeSend
+		return ir.TypeSend
 	case OrderTypeRecv:
-		return ir.TxTypeRecv
+		return ir.TypeRecv
 	default:
-		return ir.TxTypeUnknown
+		return ir.TypeUnknown
 	}
 }
 


### PR DESCRIPTION
- `Type` stands for `Buy/Sell` or `In/Out`.
- `TxType` is the specific paying definition which can be various for every provider.

**BREAKING CHANGE: the config fields(`type` and `txType`) for `huobi` and `htsec` providers are redefined in this PR, so the user who used this tool before with those providers MUST modify the config for `huobi` or `htsec` provider after upgrading the tool.**

resolves #60 

Signed-off-by: Triple-Z <me@triplez.cn>