### PR TITLE
[feat] add ledger compiler support for huobi provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ clean: ## Clean all the temporary files
 	@rm -rf ./double-entry-generator
 	@rm -rf ./wasm-dist
 
-test: test-go test-alipay-beancount test-alipay-ledger test-wechat-beancount test-wechat-ledger test-huobi-beancount test-htsec-beancount test-icbc-beancount test-icbc-ledger ## Run all tests
+test: test-go test-alipay-beancount test-alipay-ledger test-wechat-beancount test-wechat-ledger test-huobi-beancount test-huobi-ledger test-htsec-beancount test-icbc-beancount test-icbc-ledger ## Run all tests
 
 test-go: ## Run Golang tests
 	@go test ./...
@@ -107,6 +107,9 @@ test-wechat-ledger: ## Run tests for WeChat provider against ledger compiler
 
 test-huobi-beancount: ## Run tests for huobi provider against beancount compiler
 	@$(SHELL) ./test/huobi-test-beancount.sh
+
+test-huobi-ledger: ## Run tests for huobi provider against ledger compiler
+	@$(SHELL) ./test/huobi-test-ledger.sh
 
 test-htsec-beancount: ## Run tests for htsec provider against beancount compiler
 	@$(SHELL) ./test/htsec-test-beancount.sh

--- a/example/huobi/example-huobi-output.ledger
+++ b/example/huobi/example-huobi-output.ledger
@@ -1,0 +1,29 @@
+1970-01-01 * Open Balance
+    Assets:Huobi:Cash     0 CNY
+    Assets:Huobi:Positions     0 CNY
+    Assets:Rule1:Cash     0 CNY
+    Assets:Rule1:Positions     0 CNY
+    Expenses:Huobi:Commission     0 CNY
+    Expenses:Rule1:Commission     0 CNY
+    Income:Huobi:PnL     0 CNY
+    Income:Rule1:PnL     0 CNY
+    Equity:Opening Balances 
+2021-02-23 * "Huobi-币币交易" "买入-BTC/USDT"
+    Assets:Rule1:Cash     -13.98369600 "USDT"
+    Assets:Rule1:Positions     0.00030400 "BTC" @@ 13.98369600 "USDT" ; {45999.00000000 "USDT" } 
+    Assets:Rule1:Cash     -0.00000060 "BTC" @ 45999.00000000 "USDT"
+    Expenses:Rule1:Commission     0.00000060 "BTC" @ 45999.00000000 "USDT"
+
+2021-02-23 * "Huobi-币币交易" "买入-BTC1S/USDT"
+    Assets:Rule1:Cash     -5.60652159 "USDT"
+    Assets:Rule1:Positions     4.57600000 "BTC1S" @@ 5.60652159 "USDT" ; {1.22520000 "USDT" } 
+    Assets:Rule1:Cash     -0.00915201 "BTC1S" @ 1.22520000 "USDT"
+    Expenses:Rule1:Commission     0.00915201 "BTC1S" @ 1.22520000 "USDT"
+
+2021-02-24 * "Huobi-币币交易" "卖出-BTC/USDT"
+    Assets:Huobi:Positions     -0.00010800 "BTC" @ 49850.00000000 "USDT"
+    Assets:Huobi:Cash     5.38380000 "USDT"
+    Assets:Huobi:Cash     -0.01076760 "USDT"
+    Expenses:Huobi:Commission     0.01076760 "USDT"
+    Income:Huobi:PnL
+

--- a/pkg/compiler/ledger/compiler.go
+++ b/pkg/compiler/ledger/compiler.go
@@ -165,7 +165,7 @@ func (ledger *Ledger) writeBill(file io.Writer, index int) error {
 			Peer:              order.Peer,
 			Item:              order.Item,
 			Note:              order.Note,
-			Amount:            order.Money,
+			Money:             order.Money,
 			Commission:        order.Commission,
 			PlusAccount:       order.PlusAccount,
 			MinusAccount:      order.MinusAccount,

--- a/pkg/compiler/ledger/compiler.go
+++ b/pkg/compiler/ledger/compiler.go
@@ -57,6 +57,20 @@ func (ledger *Ledger) initTemplates() error {
 	if err != nil {
 		return fmt.Errorf("Failed to init the normalOrder Template. %v", err)
 	}
+
+	huobiTradeBuyOrderTemplate, err = template.New("tradeBuyOrder").Funcs(funcMap).Parse((huobiTradeBuyOrder))
+	if err != nil {
+		return fmt.Errorf("Failed to init the tradeBuyOrder template. %v", err)
+	}
+	huobiTradeBuyOrderDiffCommissionUnitTemplate, err = template.New("tradeBuyOrderDiffCommissionUnit").Funcs(funcMap).Parse(huobiTradeBuyOrderDiffCommissionUnit)
+	if err != nil {
+		return fmt.Errorf("Failed to init the tradeBuyOrderDiffCommissionUnit template. %v", err)
+	}
+	huobiTradeSellOrderTemplate, err = template.New("tradeSellOrder").Funcs(funcMap).Parse(huobiTradeSellOrder)
+	if err != nil {
+		return fmt.Errorf("Failed to init the tradeSellOrder template. %v", err)
+	}
+
 	return nil
 }
 
@@ -174,6 +188,84 @@ func (ledger *Ledger) writeBill(file io.Writer, index int) error {
 			Metadata:          order.Metadata,
 			Currency:          ledger.Config.DefaultCurrency,
 		})
+	case ir.OrderTypeHuobiTrade: // Huobi trades
+		switch order.Type {
+		case ir.TypeSend: // buy
+			isDiffCommissionUnit := false
+			commissionUnit, ok := order.Units[ir.CommissionUnit]
+			if !ok {
+				isDiffCommissionUnit = true
+			}
+			targetUnit, ok := order.Units[ir.TargetUnit]
+			if !ok {
+				isDiffCommissionUnit = true
+			}
+			if commissionUnit != targetUnit {
+				// for example, using HT for commission fee.
+				isDiffCommissionUnit = true
+			}
+
+			if isDiffCommissionUnit {
+				err = huobiTradeBuyOrderDiffCommissionUnitTemplate.Execute(&buf, &HuobiTradeBuyOrderVars{
+					PayTime:           order.PayTime,
+					Peer:              order.Peer,
+					TxTypeOriginal:    order.TxTypeOriginal,
+					TypeOriginal:      order.TypeOriginal,
+					Item:              order.Item,
+					Amount:            order.Amount,
+					Money:             order.Money,
+					Commission:        order.Commission,
+					Price:             order.Price,
+					CashAccount:       order.ExtraAccounts[ir.CashAccount],
+					PositionAccount:   order.ExtraAccounts[ir.PositionAccount],
+					CommissionAccount: order.ExtraAccounts[ir.CommissionAccount],
+					PnlAccount:        order.ExtraAccounts[ir.PnlAccount],
+					BaseUnit:          order.Units[ir.BaseUnit],
+					TargetUnit:        order.Units[ir.TargetUnit],
+					CommissionUnit:    order.Units[ir.CommissionUnit],
+				})
+			} else {
+				err = huobiTradeBuyOrderTemplate.Execute(&buf, &HuobiTradeBuyOrderVars{
+					PayTime:           order.PayTime,
+					Peer:              order.Peer,
+					TxTypeOriginal:    order.TxTypeOriginal,
+					TypeOriginal:      order.TypeOriginal,
+					Item:              order.Item,
+					Amount:            order.Amount,
+					Money:             order.Money,
+					Commission:        order.Commission,
+					Price:             order.Price,
+					CashAccount:       order.ExtraAccounts[ir.CashAccount],
+					PositionAccount:   order.ExtraAccounts[ir.PositionAccount],
+					CommissionAccount: order.ExtraAccounts[ir.CommissionAccount],
+					PnlAccount:        order.ExtraAccounts[ir.PnlAccount],
+					BaseUnit:          order.Units[ir.BaseUnit],
+					TargetUnit:        order.Units[ir.TargetUnit],
+					CommissionUnit:    order.Units[ir.CommissionUnit],
+				})
+			}
+		case ir.TypeRecv: // sell
+			err = huobiTradeSellOrderTemplate.Execute(&buf, &HuobiTradeSellOrderVars{
+				PayTime:           order.PayTime,
+				Peer:              order.Peer,
+				TxTypeOriginal:    order.TxTypeOriginal,
+				TypeOriginal:      order.TypeOriginal,
+				Item:              order.Item,
+				Amount:            order.Amount,
+				Money:             order.Money,
+				Commission:        order.Commission,
+				Price:             order.Price,
+				CashAccount:       order.ExtraAccounts[ir.CashAccount],
+				PositionAccount:   order.ExtraAccounts[ir.PositionAccount],
+				CommissionAccount: order.ExtraAccounts[ir.CommissionAccount],
+				PnlAccount:        order.ExtraAccounts[ir.PnlAccount],
+				BaseUnit:          order.Units[ir.BaseUnit],
+				TargetUnit:        order.Units[ir.TargetUnit],
+				CommissionUnit:    order.Units[ir.CommissionUnit],
+			})
+		default:
+			err = fmt.Errorf("Failed to get the TxType.")
+		}
 	}
 	if err != nil {
 		return err

--- a/pkg/compiler/ledger/template.go
+++ b/pkg/compiler/ledger/template.go
@@ -19,8 +19,8 @@ import (
 var normalOrder = `{{ .PayTime.Format "2006-01-02" }} * {{ EscapeString .Peer }} {{- if .Item }} - {{ EscapeString .Item }} {{ end }}
     {{- if .Note}}; {{ .Note }}{{ end }}
     {{- range $key, $value := .Metadata }}{{ if $value }}{{ printf "\n" }}    ; {{ $key }}: "{{ $value }}"{{end}}{{end}}
-    {{ .PlusAccount }}      {{ .Amount | printf "%.2f" }} {{ .Currency }}
-    {{ .MinusAccount }}   - {{ .Amount | printf "%.2f" }} {{ .Currency }}
+    {{ .PlusAccount }}      {{ .Money | printf "%.2f" }} {{ .Currency }}
+    {{ .MinusAccount }}   - {{ .Money | printf "%.2f" }} {{ .Currency }}
     {{- if .CommissionAccount }}{{ printf "\n" }}    {{ .CommissionAccount }}      {{ .Commission | printf "%.2f" }} {{ .Currency }}{{ end }}
     {{- if .CommissionAccount }}{{ printf "\n" }}    {{ .MinusAccount }}   - {{ .Commission | printf "%.2f" }} {{ .Currency }}{{ end }}
     {{- if .PnlAccount }}{{ printf "\n" }}	{{ .PnlAccount }}{{ end }}
@@ -32,7 +32,7 @@ type NormalOrderVars struct {
 	Peer              string            // 交易对手
 	Item              string            // 交易商品
 	Note              string            // 说明
-	Amount            float64           // 金额
+	Money             float64           // 金额
 	Commission        float64           // 手续费
 	PlusAccount       string            // 入账账户
 	MinusAccount      string            // 出账账户

--- a/pkg/compiler/ledger/template.go
+++ b/pkg/compiler/ledger/template.go
@@ -42,14 +42,105 @@ type NormalOrderVars struct {
 	Currency          string            // 货币
 }
 
-var (
-	normalOrderTemplate *template.Template
-)
+// 火币买入模版（手续费单位为购买单位货币）
 
-// 火币买入模板(TODO)
+/**
+ledger 支持单价 * 数量, 如
+; cost per item
+2010/05/31 * Market
+  Assets:Fridge                35 apples @ $0.42
+  Assets:Cash
 
-// 火币买入模板2(TODO)
+或者总价与数量(自动算出单价)
+; total cost
+2010/05/31 * Market
+  Assets:Fridge                35 apples @@ $14.70
+  Assets:Cash
 
-// 火币卖出模版(TODO)
+但不能像beancount 那样子支持同时指定单价与总价.
+2021-02-23 * "Huobi-币币交易" "买入-BTC1S/USDT"
+	Assets:Rule1:Positions     4.57600000 "BTC1S" {1.22520000 "USDT" } @@ 5.60652159 "USDT"
+	Assets:Cash
+
+因为浮点数精度的原因, 4.57600000(数量) * 1.22520000(单价) = 5.6065152000000000, 而非 5.60652159, 就会导致对账不平
+
+因此以总价及数量为标, 单价作为注释参考
+2021-02-23 * "Huobi-币币交易" "买入-BTC1S/USDT"
+	Assets:Rule1:Positions     4.57600000 "BTC1S" @@ 5.60652159 "USDT"; {1.22520000 "USDT" }
+	Assets:Cash
+**/
+
+// 火币的货币中可能包含数字, 如BTC1S, ledger 包含数字的货币解析成金额，然后报错，因此需要使用双引号 "BTC1S"
+var huobiTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
+    {{ .CashAccount }}     -{{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"
+    {{ .PositionAccount }}     {{ .Amount | printf "%.8f" }} "{{ .TargetUnit }}" @@ {{ .Money | printf "%.8f" }} "{{ .BaseUnit }}" ; { {{- .Price | printf "%.8f" }} "{{ .BaseUnit -}}" } 
+    {{ .CashAccount }}     -{{ .Commission | printf "%.8f" }} "{{ .TargetUnit }}" @ {{ .Price | printf "%.8f" }} "{{ .BaseUnit }}"
+    {{ .CommissionAccount }}     {{ .Commission | printf "%.8f" }} "{{ .CommissionUnit }}" @ {{ .Price | printf "%.8f" }} "{{ .BaseUnit }}"
+
+`
+
+type HuobiTradeBuyOrderVars struct {
+	PayTime           time.Time // 交易时间
+	Peer              string    // 交易对手
+	TxTypeOriginal    string    // 交易类型(币币交易)
+	TypeOriginal      string    // 操作类型(买入/卖出)
+	Item              string    // 交易商品
+	CashAccount       string    // 现金账号
+	PositionAccount   string
+	CommissionAccount string // 手续费账号
+	PnlAccount        string
+	Amount            float64 // 数量
+	Money             float64 // 金额
+	Commission        float64 // 手续费
+	Price             float64 // 单价
+	BaseUnit          string  // 支出货币类型
+	TargetUnit        string  // 目标货币类型
+	CommissionUnit    string  // 手续费货币类型
+}
+
+// 火币买入模版 2（手续费为特定货币）
+var huobiTradeBuyOrderDiffCommissionUnit = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
+    {{ .CashAccount }}     -{{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"
+    {{ .PositionAccount }}     {{ .Amount | printf "%.8f" }} "{{ .TargetUnit }}" @@ {{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"; { {{- .Price | printf "%.4f" }} {{ .BaseUnit -}} }
+    {{ .PositionAccount }}     -{{ .Commission | printf "%.8f" }} "{{ .CommissionUnit }}"
+    {{ .CommissionAccount }}     {{ .Commission | printf "%.8f" }} "{{ .CommissionUnit }}"
+
+`
+
+// 火币卖出模版
+var huobiTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
+    {{ .PositionAccount }}     -{{ .Amount | printf "%.8f" }} "{{ .TargetUnit }}" @ {{ .Price | printf "%.8f" }} "{{ .BaseUnit }}"
+    {{ .CashAccount }}     {{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"
+    {{ .CashAccount }}     -{{ .Commission | printf "%.8f" }} "{{ .CommissionUnit }}"
+    {{ .CommissionAccount }}     {{ .Commission | printf "%.8f" }} "{{ .CommissionUnit }}"
+    {{ .PnlAccount }}
+
+`
+
+type HuobiTradeSellOrderVars struct {
+	PayTime           time.Time // 交易时间
+	Peer              string    // 交易对手
+	TxTypeOriginal    string    // 交易类型(币币交易)
+	TypeOriginal      string    // 操作类型(买入/卖出)
+	Item              string    // 交易商品
+	CashAccount       string    // 现金账号
+	PositionAccount   string
+	CommissionAccount string // 手续费账号
+	PnlAccount        string
+	Amount            float64 // 数量
+	Money             float64 // 金额
+	Commission        float64 // 手续费
+	Price             float64 // 单价
+	BaseUnit          string  // 支出货币类型
+	TargetUnit        string  // 目标货币类型
+	CommissionUnit    string  // 手续费货币类型
+}
 
 // 海通买入模版(TODO)
+
+var (
+	normalOrderTemplate                          *template.Template
+	huobiTradeBuyOrderTemplate                   *template.Template
+	huobiTradeBuyOrderDiffCommissionUnitTemplate *template.Template
+	huobiTradeSellOrderTemplate                  *template.Template
+)

--- a/test/huobi-test-ledger.sh
+++ b/test/huobi-test-ledger.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# E2E test for huobi provider.
+
+# set -x # debug
+set -eo errexit
+
+TEST_DIR=$(dirname "$(realpath $0)")
+ROOT_DIR="$TEST_DIR/.."
+OUTPUT="$ROOT_DIR/test/output/test-huobi-output.ledger"
+
+make -f "$ROOT_DIR/Makefile" build
+mkdir -p "$ROOT_DIR/test/output"
+
+# generate huobi bills output in beancount format
+"$ROOT_DIR/bin/double-entry-generator" translate \
+    --provider huobi \
+    --target ledger \
+    --config "$ROOT_DIR/example/huobi/config.yaml" \
+    --output "$OUTPUT" \
+    "$ROOT_DIR/example/huobi/example-huobi-records.csv"
+
+diff -u --color \
+    "$ROOT_DIR/example/huobi/example-huobi-output.ledger" \
+    "$OUTPUT"
+
+if [ $? -ne 0 ]; then
+    echo "[FAIL] Huobi provider output is different from expected output."
+    exit 1
+fi
+
+echo "[PASS] All Huobi provider tests!"


### PR DESCRIPTION
## Description

目前 `double-entry-generator` 只支持 `beancount` 后端，增加对 `ledger` 后端的支持.  针对不同的 `provider`, 后端需要有对应的输出模板，已有的输出模板包括:

- [x] 普通消费账单的模板: 已支持
- [x] 火币模板1
- [x] 火币模板2
- [x] 火币卖出模板
- [ ] 海通买入模板

本次PR 增加 `火币模板1`, `火币模板2`, `火币卖出模板`的支持

## Modification
概括:

1.  `compiler/ledger` package 增加`huobi`的支持
2. `test` 目录增加 `huobi`-`ledger` 相关test script
3.  `example` 目录增加  `huobi`-`ledger` 相关的生成文件.
4. `Makefile` 增加新的 test target

## Motivation and Context

#92 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has this been tested?

新增一个 end-to-end 测试脚本, 测试 `huobi`-`ledger` 后端生成功能:

- [x] huobi-test-ledger.sh: pass

对生成的 ledger 文件进行语法与格式校验:

- [x] `ledger -f test/output/test-huobi-output.ledger bal`: pass

`make test`: all tests pass