### PR TITLE
[feat] add `ledger` compiler support for `htsec` provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ clean: ## Clean all the temporary files
 	@rm -rf ./double-entry-generator
 	@rm -rf ./wasm-dist
 
-test: test-go test-alipay-beancount test-alipay-ledger test-wechat-beancount test-wechat-ledger test-huobi-beancount test-huobi-ledger test-htsec-beancount test-icbc-beancount test-icbc-ledger ## Run all tests
+test: test-go test-alipay-beancount test-alipay-ledger test-wechat-beancount test-wechat-ledger test-huobi-beancount test-huobi-ledger test-htsec-beancount test-htsec-ledger test-icbc-beancount test-icbc-ledger ## Run all tests
 
 test-go: ## Run Golang tests
 	@go test ./...
@@ -113,6 +113,9 @@ test-huobi-ledger: ## Run tests for huobi provider against ledger compiler
 
 test-htsec-beancount: ## Run tests for htsec provider against beancount compiler
 	@$(SHELL) ./test/htsec-test-beancount.sh
+
+test-htsec-ledger: ## Run tests for htsec provider against ledger compiler
+	@$(SHELL) ./test/htsec-test-ledger.sh
 
 test-icbc-beancount: ## Run tests for ICBC provider against beancount compiler
 	@$(SHELL) ./test/icbc-test-beancount.sh

--- a/example/htsec/example-htsec-output.ledger
+++ b/example/htsec/example-htsec-output.ledger
@@ -1,0 +1,62 @@
+1970-01-01 * Open Balance
+    Assets:Htsec:Cash     0 CNY
+    Assets:Htsec:Positions     0 CNY
+    Assets:Rule1:Cash     0 CNY
+    Assets:Rule1:Positions     0 CNY
+    Expenses:Htsec:Commission     0 CNY
+    Expenses:Rule1:Commission     0 CNY
+    Income:Htsec:PnL     0 CNY
+    Income:Rule1:PnL     0 CNY
+    Equity:Opening Balances 
+2022-01-12 * "htsec" "卖-513050-中概互联"
+    Assets:Htsec:Positions     -13000.00 "SH513050" @ 1.300 CNY
+    Assets:Htsec:Cash     16900.00 CNY
+    Assets:Htsec:Cash     -0.85 CNY
+    Expenses:Htsec:Commission     0.85 CNY
+    Income:Htsec:PnL
+
+2022-01-13 * htsec-买-002304-洋河股份
+    Assets:Htsec:Cash     -16011.00 CNY
+    Assets:Htsec:Positions     100.00 "SZ002304" @@ 16011.00 CNY; {160.110 CNY}
+    Assets:Htsec:Cash     -1.60 CNY
+    Expenses:Htsec:Commission     1.60 CNY
+
+2022-01-19 * "htsec" "卖-519888-添富快线"
+    Assets:Htsec:Positions     -128.00 "SH519888" @ 0.010 CNY
+    Assets:Htsec:Cash     1.28 CNY
+    Assets:Htsec:Cash     -0.00 CNY
+    Expenses:Htsec:Commission     0.00 CNY
+    Income:Htsec:PnL
+
+2022-01-19 * htsec-买-159938-医药卫生ETF
+    Assets:Htsec:Cash     -760.80 CNY
+    Assets:Htsec:Positions     400.00 "SZ159938" @@ 760.80 CNY; {1.902 CNY}
+    Assets:Htsec:Cash     -0.04 CNY
+    Expenses:Htsec:Commission     0.04 CNY
+
+2022-01-21 * "htsec" "卖-113052-兴业转债"
+    Assets:Rule1:Positions     -10.00 "SH113052" @ 116.250 CNY
+    Assets:Rule1:Cash     1162.50 CNY
+    Assets:Rule1:Cash     -0.20 CNY
+    Expenses:Rule1:Commission     0.20 CNY
+    Income:Rule1:PnL
+
+2022-01-21 * "htsec" "卖-002027-分众传媒"
+    Assets:Htsec:Positions     -500.00 "SZ002027" @ 8.040 CNY
+    Assets:Htsec:Cash     4020.00 CNY
+    Assets:Htsec:Cash     -4.42 CNY
+    Expenses:Htsec:Commission     4.42 CNY
+    Income:Htsec:PnL
+
+2022-01-21 * htsec-买-159938-医药卫生ETF
+    Assets:Htsec:Cash     -5269.30 CNY
+    Assets:Htsec:Positions     2900.00 "SZ159938" @@ 5269.30 CNY; {1.817 CNY}
+    Assets:Htsec:Cash     -0.26 CNY
+    Expenses:Htsec:Commission     0.26 CNY
+
+2022-01-27 * htsec-买-072988-豪美发债
+    Assets:Htsec:Cash     -1000.00 CNY
+    Assets:Htsec:Positions     10.00 "SZ072988" @@ 1000.00 CNY; {100.000 CNY}
+    Assets:Htsec:Cash     -0.00 CNY
+    Expenses:Htsec:Commission     0.00 CNY
+

--- a/example/huobi/example-huobi-output.ledger
+++ b/example/huobi/example-huobi-output.ledger
@@ -8,19 +8,19 @@
     Income:Huobi:PnL     0 CNY
     Income:Rule1:PnL     0 CNY
     Equity:Opening Balances 
-2021-02-23 * "Huobi-币币交易" "买入-BTC/USDT"
+2021-02-23 * Huobi-币币交易-买入-BTC/USDT
     Assets:Rule1:Cash     -13.98369600 "USDT"
     Assets:Rule1:Positions     0.00030400 "BTC" @@ 13.98369600 "USDT" ; {45999.00000000 "USDT" } 
     Assets:Rule1:Cash     -0.00000060 "BTC" @ 45999.00000000 "USDT"
     Expenses:Rule1:Commission     0.00000060 "BTC" @ 45999.00000000 "USDT"
 
-2021-02-23 * "Huobi-币币交易" "买入-BTC1S/USDT"
+2021-02-23 * Huobi-币币交易-买入-BTC1S/USDT
     Assets:Rule1:Cash     -5.60652159 "USDT"
     Assets:Rule1:Positions     4.57600000 "BTC1S" @@ 5.60652159 "USDT" ; {1.22520000 "USDT" } 
     Assets:Rule1:Cash     -0.00915201 "BTC1S" @ 1.22520000 "USDT"
     Expenses:Rule1:Commission     0.00915201 "BTC1S" @ 1.22520000 "USDT"
 
-2021-02-24 * "Huobi-币币交易" "卖出-BTC/USDT"
+2021-02-24 * Huobi-币币交易-卖出-BTC/USDT
     Assets:Huobi:Positions     -0.00010800 "BTC" @ 49850.00000000 "USDT"
     Assets:Huobi:Cash     5.38380000 "USDT"
     Assets:Huobi:Cash     -0.01076760 "USDT"

--- a/pkg/compiler/ledger/compiler.go
+++ b/pkg/compiler/ledger/compiler.go
@@ -70,6 +70,14 @@ func (ledger *Ledger) initTemplates() error {
 	if err != nil {
 		return fmt.Errorf("Failed to init the tradeSellOrder template. %v", err)
 	}
+	htsecTradeBuyOrderTemplate, err = template.New("httradeBuyOrder").Funcs(funcMap).Parse(htsecTradeBuyOrder)
+	if err != nil {
+		return fmt.Errorf("Failed to init the httradeBuyOrder template. %v", err)
+	}
+	htsecTradeSellOrderTemplate, err = template.New("httradeSellOrder").Funcs(funcMap).Parse(htsecTradeSellOrder)
+	if err != nil {
+		return fmt.Errorf("Failed to init the httradeSellOrder template. %v", err)
+	}
 
 	return nil
 }
@@ -262,6 +270,52 @@ func (ledger *Ledger) writeBill(file io.Writer, index int) error {
 				BaseUnit:          order.Units[ir.BaseUnit],
 				TargetUnit:        order.Units[ir.TargetUnit],
 				CommissionUnit:    order.Units[ir.CommissionUnit],
+			})
+		default:
+			err = fmt.Errorf("Failed to get the TxType.")
+		}
+
+	case ir.OrderTypeSecuritiesTrade:
+		switch order.Type {
+		case ir.TypeSend: // buy
+			err = htsecTradeBuyOrderTemplate.Execute(&buf, &HtsecTradeBuyOrderVars{
+				PayTime:           order.PayTime,
+				Peer:              order.Peer,
+				TxTypeOriginal:    order.TxTypeOriginal,
+				TypeOriginal:      order.TypeOriginal,
+				Item:              order.Item,
+				Amount:            order.Amount,
+				Money:             order.Money,
+				Commission:        order.Commission,
+				Price:             order.Price,
+				CashAccount:       order.ExtraAccounts[ir.CashAccount],
+				PositionAccount:   order.ExtraAccounts[ir.PositionAccount],
+				CommissionAccount: order.ExtraAccounts[ir.CommissionAccount],
+				PnlAccount:        order.ExtraAccounts[ir.PnlAccount],
+				BaseUnit:          order.Units[ir.BaseUnit],
+				TargetUnit:        order.Units[ir.TargetUnit],
+				CommissionUnit:    order.Units[ir.CommissionUnit],
+				Currency:          ledger.Config.DefaultCurrency,
+			})
+		case ir.TypeRecv: // sell
+			err = htsecTradeSellOrderTemplate.Execute(&buf, &HtsecTradeSellOrderVars{
+				PayTime:           order.PayTime,
+				Peer:              order.Peer,
+				TxTypeOriginal:    order.TxTypeOriginal,
+				TypeOriginal:      order.TypeOriginal,
+				Item:              order.Item,
+				Amount:            order.Amount,
+				Money:             order.Money,
+				Commission:        order.Commission,
+				Price:             order.Price,
+				CashAccount:       order.ExtraAccounts[ir.CashAccount],
+				PositionAccount:   order.ExtraAccounts[ir.PositionAccount],
+				CommissionAccount: order.ExtraAccounts[ir.CommissionAccount],
+				PnlAccount:        order.ExtraAccounts[ir.PnlAccount],
+				BaseUnit:          order.Units[ir.BaseUnit],
+				TargetUnit:        order.Units[ir.TargetUnit],
+				CommissionUnit:    order.Units[ir.CommissionUnit],
+				Currency:          ledger.Config.DefaultCurrency,
 			})
 		default:
 			err = fmt.Errorf("Failed to get the TxType.")

--- a/pkg/compiler/ledger/template.go
+++ b/pkg/compiler/ledger/template.go
@@ -136,11 +136,73 @@ type HuobiTradeSellOrderVars struct {
 	CommissionUnit    string  // 手续费货币类型
 }
 
-// 海通买入模版(TODO)
+// 证券交易也以 数量 @@ 总价的方式进行计价，自动算出单价，避免精度换算导致对账不平的问题（详见上面火币的注释）
+// 证券代码如 SZ002304 带有数字，会被解析成金额，因此需要使用双引号 "SZ002304"
+
+// 海通买入模版
+var htsecTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * {{ .Peer }}-{{ .TypeOriginal }}-{{ .Item }}
+    {{ .CashAccount }}     -{{ .Money | printf "%.2f" }} {{ .Currency }}
+    {{ .PositionAccount }}     {{ .Amount | printf "%.2f" }} "{{ .TxTypeOriginal }}" @@ {{ .Money | printf "%.2f" }} {{ .Currency }}; { {{- .Price | printf "%.3f" }} {{ .Currency }}}
+    {{ .CashAccount }}     -{{ .Commission | printf "%.2f" }} {{ .Currency }}
+    {{ .CommissionAccount }}     {{ .Commission | printf "%.2f" }} {{ .Currency }}
+
+`
+
+type HtsecTradeBuyOrderVars struct {
+	PayTime           time.Time
+	Peer              string
+	TxTypeOriginal    string
+	TypeOriginal      string
+	Item              string
+	CashAccount       string
+	PositionAccount   string
+	CommissionAccount string
+	PnlAccount        string
+	Amount            float64
+	Money             float64
+	Commission        float64
+	Price             float64
+	BaseUnit          string
+	TargetUnit        string
+	CommissionUnit    string
+	Currency          string
+}
+
+// 海通卖出模板
+var htsecTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}" "{{ .TypeOriginal }}-{{ .Item }}"
+    {{ .PositionAccount }}     -{{ .Amount | printf "%.2f" }} "{{ .TxTypeOriginal }}" @ {{ .Price | printf "%.3f" }} {{ .Currency }}
+    {{ .CashAccount }}     {{ .Money | printf "%.2f" }} {{ .Currency }}
+    {{ .CashAccount }}     -{{ .Commission | printf "%.2f" }} {{ .Currency }}
+    {{ .CommissionAccount }}     {{ .Commission | printf "%.2f" }} {{ .Currency }}
+    {{ .PnlAccount }}
+
+`
+
+type HtsecTradeSellOrderVars struct {
+	PayTime           time.Time
+	Peer              string
+	TxTypeOriginal    string
+	TypeOriginal      string
+	Item              string
+	CashAccount       string
+	PositionAccount   string
+	CommissionAccount string
+	PnlAccount        string
+	Amount            float64
+	Money             float64
+	Commission        float64
+	Price             float64
+	BaseUnit          string
+	TargetUnit        string
+	CommissionUnit    string
+	Currency          string
+}
 
 var (
 	normalOrderTemplate                          *template.Template
 	huobiTradeBuyOrderTemplate                   *template.Template
 	huobiTradeBuyOrderDiffCommissionUnitTemplate *template.Template
 	huobiTradeSellOrderTemplate                  *template.Template
+	htsecTradeBuyOrderTemplate                   *template.Template
+	htsecTradeSellOrderTemplate                  *template.Template
 )

--- a/pkg/compiler/ledger/template.go
+++ b/pkg/compiler/ledger/template.go
@@ -9,7 +9,7 @@ import (
 // - https://ledger-cli.org/doc/ledger3.html
 // - https://devhints.io/ledger
 /*
-2013/01/03 * Rent for January
+2013/01/03 * Rent for January (ledger 支持中文和空格，不需要给交易商品增加双引号)
   ; comment
   Expenses:Rent   $600.00
   Assets:Savings
@@ -71,7 +71,7 @@ ledger 支持单价 * 数量, 如
 **/
 
 // 火币的货币中可能包含数字, 如BTC1S, ledger 包含数字的货币解析成金额，然后报错，因此需要使用双引号 "BTC1S"
-var huobiTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
+var huobiTradeBuyOrder = `{{ .PayTime.Format "2006-01-02" }} * {{ .Peer }}-{{ .TxTypeOriginal }}-{{ .TypeOriginal }}-{{ .Item }}
     {{ .CashAccount }}     -{{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"
     {{ .PositionAccount }}     {{ .Amount | printf "%.8f" }} "{{ .TargetUnit }}" @@ {{ .Money | printf "%.8f" }} "{{ .BaseUnit }}" ; { {{- .Price | printf "%.8f" }} "{{ .BaseUnit -}}" } 
     {{ .CashAccount }}     -{{ .Commission | printf "%.8f" }} "{{ .TargetUnit }}" @ {{ .Price | printf "%.8f" }} "{{ .BaseUnit }}"
@@ -99,7 +99,7 @@ type HuobiTradeBuyOrderVars struct {
 }
 
 // 火币买入模版 2（手续费为特定货币）
-var huobiTradeBuyOrderDiffCommissionUnit = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
+var huobiTradeBuyOrderDiffCommissionUnit = `{{ .PayTime.Format "2006-01-02" }} * {{ .Peer }}-{{ .TxTypeOriginal }}-{{ .TypeOriginal }}-{{ .Item }}
     {{ .CashAccount }}     -{{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"
     {{ .PositionAccount }}     {{ .Amount | printf "%.8f" }} "{{ .TargetUnit }}" @@ {{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"; { {{- .Price | printf "%.4f" }} {{ .BaseUnit -}} }
     {{ .PositionAccount }}     -{{ .Commission | printf "%.8f" }} "{{ .CommissionUnit }}"
@@ -108,7 +108,7 @@ var huobiTradeBuyOrderDiffCommissionUnit = `{{ .PayTime.Format "2006-01-02" }} *
 `
 
 // 火币卖出模版
-var huobiTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * "{{ .Peer }}-{{ .TxTypeOriginal }}" "{{ .TypeOriginal }}-{{ .Item }}"
+var huobiTradeSellOrder = `{{ .PayTime.Format "2006-01-02" }} * {{ .Peer }}-{{ .TxTypeOriginal }}-{{ .TypeOriginal }}-{{ .Item }}
     {{ .PositionAccount }}     -{{ .Amount | printf "%.8f" }} "{{ .TargetUnit }}" @ {{ .Price | printf "%.8f" }} "{{ .BaseUnit }}"
     {{ .CashAccount }}     {{ .Money | printf "%.8f" }} "{{ .BaseUnit }}"
     {{ .CashAccount }}     -{{ .Commission | printf "%.8f" }} "{{ .CommissionUnit }}"

--- a/test/alipay-test-ledger.sh
+++ b/test/alipay-test-ledger.sh
@@ -12,7 +12,7 @@ make -f "$ROOT_DIR/Makefile" build
 mkdir -p "$ROOT_DIR/test/output"
 OUTPUT="$ROOT_DIR/test/output/test-alipay-output.ledger"
 
-# generate alipay bills output in beancount format
+# generate alipay bills output in ledger format
 "$ROOT_DIR/bin/double-entry-generator" translate \
     --provider alipay \
     --target ledger \

--- a/test/htsec-test-ledger.sh
+++ b/test/htsec-test-ledger.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# E2E test for htsec provider.
+
+# set -x # debug
+set -eo errexit
+
+TEST_DIR=$(dirname "$(realpath $0)")
+ROOT_DIR="$TEST_DIR/.."
+OUTPUT="$ROOT_DIR/test/output/test-htsec-output.ledger"
+
+make -f "$ROOT_DIR/Makefile" build
+mkdir -p "$ROOT_DIR/test/output"
+
+# generate htsec bills output in ledger format
+"$ROOT_DIR/bin/double-entry-generator" translate \
+    --provider htsec \
+    --target ledger \
+    --config "$ROOT_DIR/example/htsec/config.yaml" \
+    --output "$OUTPUT" \
+    "$ROOT_DIR/example/htsec/example-htsec-records.xlsx"
+
+diff -u --color \
+    "$ROOT_DIR/example/htsec/example-htsec-output.ledger" \
+    "$OUTPUT"
+
+if [ $? -ne 0 ]; then
+    echo "[FAIL] htsec provider output is different from expected output."
+    exit 1
+fi
+
+echo "[PASS] All htsec provider tests!"

--- a/test/huobi-test-ledger.sh
+++ b/test/huobi-test-ledger.sh
@@ -12,7 +12,7 @@ OUTPUT="$ROOT_DIR/test/output/test-huobi-output.ledger"
 make -f "$ROOT_DIR/Makefile" build
 mkdir -p "$ROOT_DIR/test/output"
 
-# generate huobi bills output in beancount format
+# generate huobi bills output in ledger format
 "$ROOT_DIR/bin/double-entry-generator" translate \
     --provider huobi \
     --target ledger \

--- a/test/icbc-test-ledger.sh
+++ b/test/icbc-test-ledger.sh
@@ -13,7 +13,7 @@ DEBIT_OUTPUT="$ROOT_DIR/test/output/test-icbc-debit-output.ledger"
 make -f "$ROOT_DIR/Makefile" build
 mkdir -p "$ROOT_DIR/test/output"
 
-# generate icbc credit bills output in beancount format
+# generate icbc credit bills output in ledger format
 "$ROOT_DIR/bin/double-entry-generator" translate \
     --provider icbc \
     --target ledger \

--- a/test/wechat-test-ledger.sh
+++ b/test/wechat-test-ledger.sh
@@ -12,7 +12,7 @@ OUTPUT="$ROOT_DIR/test/output/test-wechat-output.ledger"
 make -f "$ROOT_DIR/Makefile" build
 mkdir -p "$ROOT_DIR/test/output"
 
-# generate wechat bills output in beancount format
+# generate wechat bills output in ledger format
 "$ROOT_DIR/bin/double-entry-generator" translate \
     --provider wechat \
     --target ledger \


### PR DESCRIPTION
## Description

目前 `double-entry-generator` 只支持 `beancount` 后端，增加对 `ledger` 后端的支持.  针对不同的 `provider`, 后端需要有对应的输出模板，已有的输出模板包括:

- [x] 普通消费账单的模板: 已支持
- [x] 火币模板1: 已支持
- [x] 火币模板2: 已支持
- [x] 火币卖出模板: 已支持
- [ ] 海通买入模板
- [ ] 海通卖出模板

本次PR 增加 `海通买入模板`, `海通卖出模板` 的支持

## Modification
概括:

1.  `compiler/ledger` package 增加`htsec`的支持
2. `test` 目录增加 `htsec`-`ledger` 相关test script
3.  `example` 目录增加  `htsec`-`ledger` 相关的生成文件.
4. `Makefile` 增加新的 test target
5. `huobi` 相关的example 和 template, 去掉商品名称的双引号, ledger 支持中文和空格，不需要加双引号表示字符串

## Motivation and Context

#92 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has this been tested?

新增一个 end-to-end 测试脚本, 测试 `htsec`-`ledger` 后端生成功能:

- [x] htsec-test-ledger.sh: pass

对生成的 ledger 文件进行语法与格式校验:

- [x] `ledger -f test/output/test-htsec-output.ledger bal`: pass

`make test`: all tests pass