### PR TITLE
Add ISSUE and PULL REQUEST template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, help wanted
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Log/Output data**
+If applicable, add log data or output data to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Description
+
+Please include a summary of the change and which issue is fixed
+
+## Motivation and Context
+
+Please also include relevant motivation and context. 
+
+## Dependencies 
+
+List any dependencies that are required for this change.
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How has this been tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
+
+Please also list any relevant details for your test configuration
+
+- [ ] Test A: xxx
+- [ ] Test B: xxx
+
+## Is this change properly documented?
+
+Please make sure you've properly documented the changes you're making.
+
+Don't forget to add an entry to the CHANGELOG/README if necessary (new features, breaking changes, relevant internal improvements).

--- a/pkg/provider/icbc/config.go
+++ b/pkg/provider/icbc/config.go
@@ -1,6 +1,6 @@
 package icbc
 
-// Config is the configuration for Alipay.
+// Config is the configuration for ICBC.
 type Config struct {
 	Rules []Rule `mapstructure:"rules,omitempty"`
 }

--- a/pkg/provider/icbc/icbc.go
+++ b/pkg/provider/icbc/icbc.go
@@ -31,7 +31,7 @@ func New() *Icbc {
 	}
 }
 
-// Translate translates the alipay bill records to IR.
+// Translate translates the icbc bill records to IR.
 func (icbc *Icbc) Translate(filename string) (*ir.IR, error) {
 	log.SetPrefix("[Provider-ICBC] ")
 


### PR DESCRIPTION
## Description

1. 增加 ISSUE 与 PULL REQUEST TEMPLATE, 方便协作者提供上下文信息
2. 修复错误注释

## Motivation and Context

提供模板供开发者提ISSUE 或PR, 统一规范与流程.

New Issue -> Choose Template:

![image](https://github.com/deb-sig/double-entry-generator/assets/14180681/8ba375bf-7da2-4738-8375-10cae052669b)

New Pull Request:

![image](https://github.com/deb-sig/double-entry-generator/assets/14180681/024c826c-ced2-4e72-a813-e748aba91240)


## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

All CI jobs pass

## Is this change properly documented?

It's unnecessary