### PR TITLE
fix(goreleaser): update go:1.24.1 & goreleaser:1.20

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -31,15 +31,15 @@ jobs:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.16
+          go-version: '1.24.1'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
           version: ~> 1.18
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.installationToken.outputs.token }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -39,7 +39,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
-          version: ~> 1.18
+          version: ~> 1.20
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.installationToken.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,12 +31,12 @@ builds:
 archives:
   - 
     id: double-entry-generator
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -54,7 +54,7 @@ brews:
     name: double-entry-generator
     ids:
       - double-entry-generator
-    tap:
+    repository:
       owner: deb-sig
       name: homebrew-tap
       branch: main

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ check-format: ## Check if the format looks good.
 	@go fmt ./...
 
 goreleaser-build-test: ## Goreleaser build for testing
-	goreleaser build --single-target --snapshot --rm-dist
+	goreleaser build --single-target --snapshot --clean
 
 clean-wasm: ## Clean wasm-dist dir
 	@rm -rf ./wasm-dist

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/deb-sig/double-entry-generator
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24
 
 require (
 	github.com/extrame/xls v0.0.2-0.20200426124601-4a6cf263071b


### PR DESCRIPTION
- remove deprecated commands

For version 2.8.0