### PR TITLE
feat(ccb): support matching item (transaction location) in rules

### DIFF
--- a/pkg/analyser/alipay/alipay.go
+++ b/pkg/analyser/alipay/alipay.go
@@ -140,7 +140,10 @@ func (a Alipay) GetAccountsAndTags(o *ir.Order, cfg *config.Config, target, prov
 		}
 	}
 
-	if strings.HasPrefix(o.Item, "退款-") && ir.TypeRecv != o.Type {
+	isRefund := strings.HasPrefix(o.Item, "退款-") ||
+		o.Category == "退款" ||
+		o.Metadata["status"] == "退款成功"
+	if isRefund && ir.TypeRecv != o.Type {
 		return ignore, resPlus, resMinus, extraAccounts, tags
 	}
 	return ignore, resMinus, resPlus, extraAccounts, tags


### PR DESCRIPTION
- Match r.Item against o.Item in GetAccountsAndTags using matchFunc
- Document `item` option in README alongside peer/type/txType

## Description

Fix https://github.com/deb-sig/double-entry-generator/issues/179

## Motivation and Context

支付宝可能不出现在 peer 字段，因此添加 item 字段匹配方便 ignore

## Dependencies 

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

None

## Is this change properly documented?

Yes