### PR TITLE
fix(bocom_credit): 修复部分交易类型无法识别的问题

### DIFF
--- a/pkg/provider/bocom_credit/util.go
+++ b/pkg/provider/bocom_credit/util.go
@@ -81,9 +81,9 @@ func splitDescription(description string) (string, string) {
 
 func inferOrderType(typeOriginal string) (OrderType, error) {
 	switch strings.TrimSpace(typeOriginal) {
-	case "退货", "信用卡还款", "红包还款", "刷卡金返还":
+	case "退货", "信用卡还款", "红包还款", "刷卡金返还", "自动购汇还款":
 		return OrderTypeRecv, nil
-	case "消费", "刷卡金扣回":
+	case "消费", "刷卡金扣回", "分期扣款", "自动购汇扣款":
 		return OrderTypeSend, nil
 	default:
 		return OrderTypeUnknown, fmt.Errorf("unsupported transaction type: %s", typeOriginal)


### PR DESCRIPTION
## Description

This change updates bocom_credit transaction type inference to recognize additional transaction types:

 - 自动购汇还款
 - 分期扣款
 - 自动购汇扣款

## Motivation and Context

Some Bank of Communications credit card transaction records contain transaction types that were not covered by the existing mapping logic.

As a result, parsing could fail with unsupported transaction type errors.

This change expands the supported type mapping so these records can be classified correctly:

 - 自动购汇还款 -> OrderTypeRecv
 - 分期扣款 -> OrderTypeSend
 - 自动购汇扣款 -> OrderTypeSend

## Dependencies 

No additional dependencies are required for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

manually verified

## Is this change properly documented?

- [x] No documentation update is required for this change.
