### PR TITLE
[fix] 优化中文文档搜索词典

### DIFF
--- a/docs/vendor/mkdocs-search-jieba/LICENSE.jieba
+++ b/docs/vendor/mkdocs-search-jieba/LICENSE.jieba
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Sun Junyi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/vendor/mkdocs-search-jieba/README.md
+++ b/docs/vendor/mkdocs-search-jieba/README.md
@@ -1,0 +1,5 @@
+# mkdocs-search-jieba
+
+Local MkDocs search plugin for Chinese tokenization.
+
+`mkdocs_search_jieba/dict.txt` is bundled from jieba v0.42.1 so docs builds use a known-good UTF-8 dictionary instead of the environment's installed `jieba/dict.txt`. See `LICENSE.jieba` for the upstream dictionary license.

--- a/docs/vendor/mkdocs-search-jieba/mkdocs_search_jieba/__init__.py
+++ b/docs/vendor/mkdocs-search-jieba/mkdocs_search_jieba/__init__.py
@@ -11,6 +11,8 @@ from mkdocs.plugins import BasePlugin
 
 log = logging.getLogger(__name__)
 ZWS = "\u200b"
+JIEBA_DICT = Path(__file__).resolve().parent / "dict.txt"
+_segmenter = None
 
 # lunr 在加载时把 QueryLexer.termSeparator 设为当时的 tokenizer.separator，之后 worker 只改了
 # tokenizer.separator，导致查询分词仍用默认分隔符、\u200b 不生效。构建后补一行同步 termSeparator。
@@ -105,14 +107,29 @@ MAIN_FORMATRESULT_OLD = "joinUrl(base_url, location)"
 MAIN_FORMATRESULT_NEW = "joinUrl(_linkBase, location)"
 
 
-def _segment_chinese(text: str) -> str:
+def _get_segmenter():
+    global _segmenter
+    if _segmenter is not None:
+        return _segmenter
+
     try:
         import jieba
-    except ImportError:
-        return text
+    except ImportError as e:
+        raise RuntimeError("未安装 jieba，无法构建中文搜索索引。请运行: uv sync") from e
+
+    jieba.set_dictionary(str(JIEBA_DICT))
+    # Force dictionary initialization here so dictionary problems fail during
+    # config loading, not halfway through page rendering.
+    list(jieba.cut("中文搜索"))
+    _segmenter = lambda s: list(jieba.cut(s))
+    return _segmenter
+
+
+def _segment_chinese(text: str) -> str:
+    segmenter = _get_segmenter()
 
     def replace_chinese(m: re.Match) -> str:
-        return ZWS.join(jieba.cut(m.group(0)))
+        return ZWS.join(segmenter(m.group(0)))
 
     return re.sub(r"[\u4e00-\u9fff]+", replace_chinese, text)
 
@@ -128,11 +145,7 @@ def _patched_add_entry(self, title: str | None, text: str, loc: str) -> None:
 
 class SearchJiebaPlugin(BasePlugin):
     def on_config(self, config, **kwargs):
-        try:
-            import jieba
-        except ImportError:
-            log.warning("未安装 jieba，中文搜索将不可用。请运行: uv add jieba")
-            return config
+        _get_segmenter()
 
         from mkdocs.contrib.search import search_index
 

--- a/docs/vendor/mkdocs-search-jieba/pyproject.toml
+++ b/docs/vendor/mkdocs-search-jieba/pyproject.toml
@@ -16,3 +16,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["mkdocs_search_jieba"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"prebuild-index-cjk.js" = "prebuild-index-cjk.js"
+"mkdocs_search_jieba/dict.txt" = "mkdocs_search_jieba/dict.txt"
+"LICENSE.jieba" = "LICENSE.jieba"


### PR DESCRIPTION
## Description

为 MkDocs 搜索补充本地 jieba 词典，使中文文档搜索可以更稳定地分词和命中模板 Provider 相关内容。

本 PR 未关联具体 issue。

## Motivation and Context

文档搜索依赖中文分词效果。默认分词在部分中文术语、Provider 名称和导入规则关键词上命中不够稳定。

本 PR 将 jieba 词典作为文档构建资源提交，避免本地或 CI 环境因为缺少词典导致中文搜索效果不一致。

## Dependencies

无运行时依赖。

该变更只影响文档搜索构建资源，不影响 DEG CLI 或 Provider 解析逻辑。

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has this been tested?

已在本地验证文档搜索可以正常使用中文查询。

- [x] Test A: 本地启动文档预览并验证搜索框可正常返回中文结果
- [x] Test B: 确认本 PR 只包含 `docs/vendor/mkdocs-search-jieba` 下的词典与插件资源

## Is this change properly documented?

是。该 PR 本身是文档搜索资源补充，不需要额外用户使用文档。