### PR TITLE
feat: 支付宝平台增加保留退款记录开关

### DIFF
--- a/docs/docs/en/providers/payment/alipay.md
+++ b/docs/docs/en/providers/payment/alipay.md
@@ -41,6 +41,8 @@ title: Alipay Bill Conversion
 layout: default
 
 alipay:
+  # Keep matched refund records and their original orders for reconciliation.
+  keepRefundRecords: false
   rules:
     # Income transactions
     - type: 收入
@@ -122,6 +124,17 @@ The Alipay Provider provides rule-based matching, you can specify:
 - `methodAccount`: Specify payment account (e.g., balance, credit card, etc.)
 - `targetAccount`: Specify target account
 - `pnlAccount`: Investment profit and loss account (for fund, gold trading)
+
+### Refund Reconciliation
+
+By default, when a full refund record is matched with its original order in the same CSV file, the Provider removes both records. A refund can arrive later than the original order; to keep both records for period reconciliation, configure:
+
+```yaml
+alipay:
+  keepRefundRecords: true
+```
+
+This option only disables automatic removal of matched refund records and their original orders. Unmatched refunds, partial refunds, refunds across files, rule-level `ignore: true`, and closed non-income/non-expense records keep their existing behavior.
 
 ## Account Relationships
 

--- a/docs/docs/providers/payment/alipay.md
+++ b/docs/docs/providers/payment/alipay.md
@@ -41,6 +41,8 @@ title: 支付宝账单转换
 layout: default
 
 alipay:
+  # 保留已匹配的退款记录和原交易，便于对账
+  keepRefundRecords: false
   rules:
     # 收入类交易
     - type: 收入
@@ -122,6 +124,17 @@ alipay:
 - `methodAccount`: 指定支付账户（如余额、信用卡等）
 - `targetAccount`: 指定目标账户
 - `pnlAccount`: 投资收益账户（用于基金、黄金交易）
+
+### 退款对账
+
+默认情况下，如果同一 CSV 文件中的全额退款记录能够匹配到原交易，Provider 会同时移除这两条记录。退款可能晚于原交易到账；需要保留两条记录进行阶段性对账时，可以设置：
+
+```yaml
+alipay:
+  keepRefundRecords: true
+```
+
+该选项只影响已匹配退款记录与原交易的自动移除。未匹配退款、部分退款、跨文件退款、规则中的 `ignore: true`，以及“交易关闭且不计收支”记录的处理方式保持不变。
 
 ## 账户关系
 

--- a/example/alipay/config.yaml
+++ b/example/alipay/config.yaml
@@ -3,6 +3,8 @@ defaultPlusAccount: Expenses:FIXME
 defaultCurrency: CNY
 title: 测试
 alipay:
+  # 保留已匹配的退款记录和原交易，便于退款到账前后的对账
+  keepRefundRecords: false
   rules:
     # 泛匹配结果应当放在前面
     - type: 收入 # 其他转账收款

--- a/pkg/cmd/translate.go
+++ b/pkg/cmd/translate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/deb-sig/double-entry-generator/v2/pkg/config"
 	"github.com/deb-sig/double-entry-generator/v2/pkg/consts"
 	"github.com/deb-sig/double-entry-generator/v2/pkg/provider"
+	"github.com/deb-sig/double-entry-generator/v2/pkg/provider/alipay"
 	_ "github.com/deb-sig/double-entry-generator/v2/pkg/provider/bmo"
 	_ "github.com/deb-sig/double-entry-generator/v2/pkg/provider/ccb"
 	_ "github.com/deb-sig/double-entry-generator/v2/pkg/provider/citic"
@@ -112,6 +113,12 @@ func run(args []string) {
 
 	p, err := provider.New(providerName)
 	logErrorIfNotNil(err)
+
+	if providerName == consts.ProviderAlipay {
+		if a, ok := p.(*alipay.Alipay); ok {
+			a.Config = c.Alipay
+		}
+	}
 
 	if providerName == consts.ProviderWechat {
 		if w, ok := p.(*wechat.Wechat); ok {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestUnmarshalAlipayKeepRefundRecords(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader("alipay:\n  keepRefundRecords: true\n")); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	var cfg Config
+	if err := v.Unmarshal(&cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if cfg.Alipay == nil || !cfg.Alipay.KeepRefundRecords {
+		t.Fatal("expected alipay.keepRefundRecords to be true")
+	}
+}

--- a/pkg/provider/alipay/alipay.go
+++ b/pkg/provider/alipay/alipay.go
@@ -32,6 +32,7 @@ type Alipay struct {
 	Statistics Statistics `json:"statistics,omitempty"`
 	LineNum    int        `json:"line_num,omitempty"`
 	Orders     []Order    `json:"orders,omitempty"`
+	Config     *Config    `json:"-"`
 
 	// TitleParsed is a workaround to ignore the title row.
 	TitleParsed bool `json:"title_parsed,omitempty"`
@@ -43,6 +44,7 @@ func New() *Alipay {
 		Statistics:  Statistics{},
 		LineNum:     0,
 		Orders:      make([]Order, 0),
+		Config:      nil,
 		TitleParsed: false,
 	}
 }
@@ -99,7 +101,7 @@ func (a *Alipay) postProcess(ir_ *ir.IR) *ir.IR {
 	for i := 0; i < len(ir_.Orders); i++ {
 		var order = ir_.Orders[i]
 		// found alipay refund tx
-		if order.Metadata["status"] == "退款成功" && order.Category == "退款" {
+		if !a.keepRefundRecords() && order.Metadata["status"] == "退款成功" && order.Category == "退款" {
 			for j := 0; j < len(ir_.Orders); j++ {
 				// find the order corresponding to the refund
 				// (different tx) && (prefix match) && (money equal)
@@ -138,4 +140,8 @@ func (a *Alipay) postProcess(ir_ *ir.IR) *ir.IR {
 	ir_.Orders = orders
 	// 超时
 	return ir_
+}
+
+func (a *Alipay) keepRefundRecords() bool {
+	return a.Config != nil && a.Config.KeepRefundRecords
 }

--- a/pkg/provider/alipay/alipay_test.go
+++ b/pkg/provider/alipay/alipay_test.go
@@ -1,0 +1,96 @@
+package alipay
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/deb-sig/double-entry-generator/v2/pkg/ir"
+)
+
+func TestAlipayConfigIsNotSerialized(t *testing.T) {
+	provider := New()
+	provider.Config = &Config{KeepRefundRecords: true}
+
+	data, err := json.Marshal(provider)
+	if err != nil {
+		t.Fatalf("marshal provider: %v", err)
+	}
+	if strings.Contains(string(data), "keepRefundRecords") {
+		t.Fatal("expected runtime config to be excluded from provider JSON")
+	}
+}
+
+func TestPostProcessRemovesMatchedRefundPairByDefault(t *testing.T) {
+	provider := New()
+	processed := provider.postProcess(refundPairIR())
+
+	if got := len(processed.Orders); got != 0 {
+		t.Fatalf("expected matched refund pair to be removed, got %d orders", got)
+	}
+}
+
+func TestPostProcessKeepsMatchedRefundPairWhenConfigured(t *testing.T) {
+	provider := New()
+	provider.Config = &Config{KeepRefundRecords: true}
+	processed := provider.postProcess(refundPairIR())
+
+	if got := len(processed.Orders); got != 2 {
+		t.Fatalf("expected matched refund pair to be kept, got %d orders", got)
+	}
+}
+
+func TestPostProcessKeepsPartialRefund(t *testing.T) {
+	provider := New()
+	processed := provider.postProcess(&ir.IR{Orders: []ir.Order{
+		refundOrder("order-1-refund", 10),
+		originalOrder("order-1", 20),
+	}})
+
+	if got := len(processed.Orders); got != 2 {
+		t.Fatalf("expected partial refund pair to remain, got %d orders", got)
+	}
+}
+
+func TestPostProcessClosedNonIncomeExpenseRemainsIndependent(t *testing.T) {
+	provider := New()
+	provider.Config = &Config{KeepRefundRecords: true}
+	processed := provider.postProcess(&ir.IR{Orders: []ir.Order{
+		refundOrder("order-1-refund", 10),
+		originalOrder("order-1", 10),
+		{
+			Metadata: map[string]string{
+				"status":  "交易关闭",
+				"type":    "不计收支",
+				"orderId": "closed-1",
+			},
+		},
+	}})
+
+	if got := len(processed.Orders); got != 2 {
+		t.Fatalf("expected only closed transaction to be removed, got %d orders", got)
+	}
+}
+
+func refundPairIR() *ir.IR {
+	return &ir.IR{Orders: []ir.Order{
+		refundOrder("order-1-refund", 10),
+		originalOrder("order-1", 10),
+	}}
+}
+
+func refundOrder(orderID string, money float64) ir.Order {
+	return ir.Order{
+		Money:    money,
+		Category: "退款",
+		Type:     ir.TypeSend,
+		Metadata: map[string]string{"status": "退款成功", "orderId": orderID},
+	}
+}
+
+func originalOrder(orderID string, money float64) ir.Order {
+	return ir.Order{
+		Money:    money,
+		Metadata: map[string]string{"status": "交易成功", "orderId": orderID},
+	}
+}

--- a/pkg/provider/alipay/config.go
+++ b/pkg/provider/alipay/config.go
@@ -18,7 +18,10 @@ package alipay
 
 // Config is the configuration for Alipay.
 type Config struct {
-	Rules []Rule `mapstructure:"rules,omitempty"`
+	// KeepRefundRecords keeps a matched refund record and its original order
+	// in the intermediate representation for reconciliation.
+	KeepRefundRecords bool   `mapstructure:"keepRefundRecords,omitempty" yaml:"keepRefundRecords,omitempty"`
+	Rules             []Rule `mapstructure:"rules,omitempty"`
 }
 
 // Rule is the type for match rules.

--- a/pkg/wasm/simple_file_reader.go
+++ b/pkg/wasm/simple_file_reader.go
@@ -73,6 +73,9 @@ func (fr *SimpleFileReader) ProcessFileWithFormat(fileName string, fileData []by
 	switch fr.currentProvider {
 	case "alipay":
 		provider := alipay.New()
+		if fr.config != nil {
+			provider.Config = fr.config.Alipay
+		}
 		// Alipay 只支持 CSV
 		orders, err = provider.Translate(string(fileData))
 


### PR DESCRIPTION
## Description

为支付宝（Alipay）Provider 新增 keepRefundRecords 配置开关，用于保留已匹配的退款记录及对应原交易。                                                                     
                                                                                                                                                                        
现状：当同一 CSV 文件中的全额退款记录能匹配到原交易时，Provider 在 postProcess 中会同时移除这两条记录（退款冲销原交易，避免重复记账）。                                
                                                                                                                                                                        
问题：退款往往晚于原交易到账（例如跨月）。原交易已计入上一周期，而当前周期的退款记录被静默丢弃，导致阶段性对账（如月度对账）金额不符。                                 
                                                                                                                                                                        
改动：新增 alipay.keepRefundRecords: true 配置后，不再自动移除已匹配的退款记录与原交易，两条记录都会保留在中间表示（IR）中，供用户自行对账/处理。

## Motivation and Context

- 退款记录可能晚于原交易数月到账，默认的"匹配即移除"策略会破坏跨周期的对账准确性。
- 提供显式开关，让用户在对账场景下保留退款记录，同时保持默认行为（移除）不变，避免破坏现有用户的使用习惯。                                                             
- 仅影响"已匹配的退款记录 + 原交易"的自动移除；未匹配退款、部分退款、跨文件退款、规则级 ignore: true 以及"交易关闭且不计收支"记录的行为保持不变（已在文档中说明）。

## Dependencies 

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How has this been tested?

- Test A: pkg/provider/alipay/alipay_test.go — 新增 96 行测试，覆盖 keepRefundRecords: true/false 两种开关下已匹配退款记录的保留/移除行为                              
- Test B: pkg/config/config_test.go — 新增 24 行测试，验证 keepRefundRecords 配置项解析                                                                                
- Test C: 运行 go test ./... 全量测试通过（改动涉及的 pkg/cmd/translate.go、pkg/wasm/simple_file_reader.go 为配置注入逻辑，随包测试覆盖）   

## Is this change properly documented?

- 中文文档：docs/docs/providers/payment/alipay.md — 新增「退款对账」小节，说明开关语义及不受影响的行为                                                                 
- 英文文档：docs/docs/en/providers/payment/alipay.md — 同步更新（"Refund Reconciliation"）                                                                             
- 示例配置：example/alipay/config.yaml — 补充 keepRefundRecords: false 注释示例  
